### PR TITLE
clarifying secondary servers

### DIFF
--- a/4.4/data-integrate/ssis/set-up-the-odbc-driver-using-ssis.html
+++ b/4.4/data-integrate/ssis/set-up-the-odbc-driver-using-ssis.html
@@ -2756,7 +2756,7 @@ You now want to create sources and destinations.</li>
   <li>
     <p>In the Client Configuration Dialog, enter the <strong>Server IP</strong> and <strong>Server Port</strong>.</p>
 
-    <p>Any node IP that has Simba server running on it should work. You can provide multiple IPs (using the <strong>Secondary Servers</strong> dialog) so that it will find the one that the Simba server is running on.</p>
+    <p>Any node IP that has Simba server running on it should work. You can provide multiple IPs (using the <strong>Secondary Servers</strong> dialog) so that it will find the one that the Simba server is running on. Please note, the secondary servers list is one IP per line, and not comma seperated.</p>
   </li>
   <li>
     <p>Click <strong>OK</strong> twice to close the Client Configuration Dialog and the ODBC Data Source Administrator.</p>


### PR DESCRIPTION
Clarifying that secondary servers in SSIS are one IP per line, and not comma separated.