### PR TITLE
Correct one sentence in choose-strategy.md

### DIFF
--- a/_admin/backup-restore/choose-strategy.md
+++ b/_admin/backup-restore/choose-strategy.md
@@ -10,7 +10,7 @@ This section discusses three strategies for backing up your ThoughtSpot cluster.
 
 ## Snapshots
 
-A snapshot is a point-in-time image of your running cluster. Snapshots are both taken on and restored to a cluster while it is running. Each cluster has a enabled by default a snapshot configuration. This configuration instructs the system to periodically take snapshots. Creation of a snapshot takes about 20 seconds. Once taken, a snapshot is persisted on disk in the cluster's HDFS.
+A snapshot is a point-in-time image of your running cluster. Snapshots are both taken on and restored to a cluster while it is running. Each cluster has a periodic snapshot configuration enabled by default. This configuration instructs the system to periodically take snapshots. Creation of a snapshot takes about 20 seconds. Once taken, a snapshot is persisted on disk in the cluster's HDFS.
 
 You can also create a snapshot manually. You should create a snapshot before making any changes to the environment, loading a large amount of new data, or changing the structure of a table. A snapshot may only be restored to the same cluster on which it was taken. The cluster software release version must match the snapshot release version.
 


### PR DESCRIPTION
“Each cluster has *a* enabled by default a snapshot configuration.”

There’s a grammar mistake and I think the whole sentence is ambiguous.
Would it be rather something like below?

"Each cluster has a periodic snapshot configuration enabled by default"