### PR TITLE
Added info : tscli scheduled-pinboard enable

### DIFF
--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -647,6 +647,7 @@ This subcommand has the following actions:
 * `tscli scheduled-pinboards disable [-h]` Disable scheduled pinboards for this cluster.
 * `tscli scheduled-pinboards enable [-h]` Enables scheduled pinboards, which is disabled in prod clusters by default.
 
+Note that enabling scheduled pinboards is accompanied by setting up a whitelist of intended email domains. ThoughtSpot support can help with that.
 
 ###  smtp
 


### PR DESCRIPTION
tscli scheduled-pinboard enable : needs to set up along with a whitelist of domains. Without that option specified, this one command is somewhat risky and shouldn't be implemented. Without a whitelist it may not even work (as the list of whitelisted domains will be empty).
So I've added a tip about that.
Ideally, the whitelist needs to be specified via tscli as well.