### PR TITLE
Terminology.

### DIFF
--- a/_appliance/vmware/vmware-intro.md
+++ b/_appliance/vmware/vmware-intro.md
@@ -31,7 +31,7 @@ ThoughtSpot VMs as your dataset size grows.
 ThoughtSpot Engineering has performed extensive testing of the ThoughtSpot
 platform on the VMWare for the best performance, load balancing, scalability,
 and reliability. Based on this testing, ThoughtSpot recommends the following
-minimum specifications for individual VMWare ESXi host:
+minimum specifications for individual VMWare ESXi VM:
 
 * 512G Memory
 * 200G SSD


### PR DESCRIPTION
The doc uses wrong wording for the VMWare VMs. It calls them *host*
It’s confusing for someone who works with virtualisation. Host is hypervisor, VM is guest.