### PR TITLE
Fixed problem with HTML table tags showing on release notes page

### DIFF
--- a/_release/notes.md
+++ b/_release/notes.md
@@ -17,7 +17,7 @@ permalink: /:collection/:path.html
 <p>4.2.3, 4.3, 4.4.X and any hotfixes or customer patches on these branches</p>
 <p>If you are running a different version, you need to do a multiple pass upgrade. First, upgrade to one of the above versions, and then to this release.</p>
 <h2><br />4.5 New&nbsp;Features and Functionality&nbsp;</h2>
-<table style="border-collapse: collapse; width: 100%;" border="0" border-collapse: collapse; padding="0">
+
 <thead>
 <tr style="width: 100%;border-bottom-style: inset;">
 </tr>
@@ -419,9 +419,9 @@ permalink: /:collection/:path.html
 </td>
 </tr>
 </tbody>
-</table>
+
 <h2>4.5 Fixed Bugs&nbsp;</h2>
-<table style="border-collapse: collapse; width: 100%;" border="0" border-collapse: collapse; padding="0">
+
 <thead>
 <tr style="width: 100%;border-bottom-style: inset;">
 </tr>
@@ -684,7 +684,7 @@ permalink: /:collection/:path.html
 </td>
 </tr>
 </tbody>
-</table>
+
 <h2>Notes for older versions</h2>
 <ul>
 <li><a href="{{"/4.4/release/notes.html" | prepend: site.baseurl }}">4.4 Release Notes</a></li>


### PR DESCRIPTION
### What's changed

- Starting with v `4.5`, 2 sets of open/close HTML table tags were showing on the release page. They were being generated from markdown to HTML as quoted text, not HTML tags.
- Removed the open/close table tags and the output HTML looks good now. (The layout or format for this page changed from v `4.4.x` to `4.5` so maybe this was related.) 

Signed-off-by: Victoria Bialas <victoria.bialas@thoughtspot.com>