### PR TITLE
SCAL-30739 add Safari as a supported browser

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.17.9)
+    commonmarker (0.17.10)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
     dnsruby (1.61.2)
@@ -30,7 +30,7 @@ GEM
     ffi (1.9.25)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
-    github-pages (188)
+    github-pages (189)
       activesupport (= 4.2.10)
       github-pages-health-check (= 1.8.1)
       jekyll (= 3.7.3)
@@ -66,7 +66,7 @@ GEM
       jekyll-theme-tactile (= 0.1.1)
       jekyll-theme-time-machine (= 0.1.1)
       jekyll-titles-from-headings (= 0.5.1)
-      jemoji (= 0.10.0)
+      jemoji (= 0.10.1)
       kramdown (= 1.16.2)
       liquid (= 4.0.0)
       listen (= 3.1.5)
@@ -81,7 +81,7 @@ GEM
       octokit (~> 4.0)
       public_suffix (~> 2.0)
       typhoeus (~> 1.3)
-    html-pipeline (2.8.3)
+    html-pipeline (2.8.4)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.6.0)
@@ -187,11 +187,11 @@ GEM
       jekyll (~> 3.3)
     jekyll-watch (2.0.0)
       listen (~> 3.0)
-    jemoji (0.10.0)
+    jemoji (0.10.1)
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (~> 3.0)
-    json (1.8.3.1)
+    json (1.8.3)
     kramdown (1.16.2)
     liquid (4.0.0)
     listen (3.1.5)
@@ -243,7 +243,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (= 188)
+  github-pages (= 189)
   jekyll-redirect-from
   jekyll-seo-tag
   jekyll-sitemap

--- a/_includes/content/log_in_out.md
+++ b/_includes/content/log_in_out.md
@@ -36,6 +36,11 @@ The following browsers are verified to work well with the ThoughtSpot applicatio
       <td>11</td>
       <td>Windows 7 or greater</td>
     </tr>
+    <tr>
+      <td>Safari</td>
+      <td>10 or greater</td>
+      <td>MacOS</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Adding Safari as a supported browser, related [SCAL-30739](https://thoughtspot.atlassian.net/browse/SCAL-30739)

Signed-off-by: Alicia Avrach <alicia@thoughtspot.com>