### PR TITLE
Keywords Japanese and German cheatsheets markdown source

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.17.10)
+    commonmarker (0.17.11)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
     dnsruby (1.61.2)
@@ -30,7 +30,7 @@ GEM
     ffi (1.9.25)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
-    github-pages (189)
+    github-pages (191)
       activesupport (= 4.2.10)
       github-pages-health-check (= 1.8.1)
       jekyll (= 3.7.3)
@@ -41,7 +41,7 @@ GEM
       jekyll-feed (= 0.10.0)
       jekyll-gist (= 1.5.0)
       jekyll-github-metadata (= 2.9.4)
-      jekyll-mentions (= 1.4.0)
+      jekyll-mentions (= 1.4.1)
       jekyll-optional-front-matter (= 0.3.0)
       jekyll-paginate (= 1.1.0)
       jekyll-readme-index (= 0.2.0)
@@ -67,7 +67,7 @@ GEM
       jekyll-theme-time-machine (= 0.1.1)
       jekyll-titles-from-headings (= 0.5.1)
       jemoji (= 0.10.1)
-      kramdown (= 1.16.2)
+      kramdown (= 1.17.0)
       liquid (= 4.0.0)
       listen (= 3.1.5)
       mercenary (~> 0.3)
@@ -121,7 +121,7 @@ GEM
     jekyll-github-metadata (2.9.4)
       jekyll (~> 3.1)
       octokit (~> 4.0, != 4.4.0)
-    jekyll-mentions (1.4.0)
+    jekyll-mentions (1.4.1)
       html-pipeline (~> 2.3)
       jekyll (~> 3.0)
     jekyll-optional-front-matter (0.3.0)
@@ -191,8 +191,7 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (~> 3.0)
-    json (1.8.3)
-    kramdown (1.16.2)
+    kramdown (1.17.0)
     liquid (4.0.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -208,7 +207,7 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
-    octokit (4.9.0)
+    octokit (4.10.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
@@ -243,11 +242,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (= 189)
+  github-pages (= 191)
   jekyll-redirect-from
   jekyll-seo-tag
   jekyll-sitemap
-  json
 
 BUNDLED WITH
    1.16.2

--- a/_includes/content/keywords-comparative-de-DE.md
+++ b/_includes/content/keywords-comparative-de-DE.md
@@ -1,0 +1,60 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-31q5{background-color:#000000;color:#ffcd33;vertical-align:top}
+.tg .tg-b7b8{background-color:#f9f9f9;vertical-align:top}
+.tg .tg-yw4l{vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-31q5">Keywords</th>
+    <th class="tg-31q5">Deutsche</th>
+    <th class="tg-31q5">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">all</td>
+    <td class="tg-b7b8">alle</td>
+    <td class="tg-b7b8"><code>all</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">between... and</td>
+    <td class="tg-yw4l">zwischen … und</td>
+    <td class="tg-yw4l"><code>revenue between 0 and 1000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">vs, versus</td>
+    <td class="tg-b7b8">vs, versus</td>
+    <td class="tg-b7b8"><code>revenue east vs west</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">&gt;</td>
+    <td class="tg-yw4l">&gt;</td>
+    <td class="tg-yw4l"><code>sum sale amount by visitor by product for last year sale amount &gt; 2000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">&lt;</td>
+    <td class="tg-b7b8">&lt;</td>
+    <td class="tg-b7b8"><code>unique count visitor by product by store for sale amount &lt; 20</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">&gt;=</td>
+    <td class="tg-yw4l">&gt;=</td>
+    <td class="tg-yw4l"><code>count calls by employee lastname &gt;= m</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">&lt;=</td>
+    <td class="tg-b7b8">&lt;=</td>
+    <td class="tg-b7b8"><code>count shipments by city latitude &lt;= 0</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">=</td>
+    <td class="tg-yw4l">=</td>
+    <td class="tg-yw4l"><code>unique count visitor by store purchased products = 3 for last 5 days</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">!=</td>
+    <td class="tg-b7b8">!=</td>
+    <td class="tg-b7b8"><code>sum sale amount region != canada region != mexico</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-comparative-ja-JP.md
+++ b/_includes/content/keywords-comparative-ja-JP.md
@@ -1,0 +1,60 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-8env{background-color:#fe0000;color:#ffffff;vertical-align:top}
+.tg .tg-b7b8{background-color:#f9f9f9;vertical-align:top}
+.tg .tg-yw4l{vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-8env">Keywords</th>
+    <th class="tg-8env">日本語</th>
+    <th class="tg-8env">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">all</td>
+    <td class="tg-b7b8">すべて</td>
+    <td class="tg-b7b8"><code>all</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">between... and</td>
+    <td class="tg-yw4l">間 … および</td>
+    <td class="tg-yw4l"><code>revenue between 0 and 1000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">vs, versus</td>
+    <td class="tg-b7b8">対、対</td>
+    <td class="tg-b7b8"><code>revenue east vs west</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">&gt;</td>
+    <td class="tg-yw4l">&gt;</td>
+    <td class="tg-yw4l"><code>sum sale amount by visitor by product for last year sale amount &gt; 2000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">&lt;</td>
+    <td class="tg-b7b8">&lt;</td>
+    <td class="tg-b7b8"><code>unique count visitor by product by store for sale amount &lt; 20</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">&gt;=</td>
+    <td class="tg-yw4l">&gt;=</td>
+    <td class="tg-yw4l"><code>count calls by employee lastname &gt;= m</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">&lt;=</td>
+    <td class="tg-b7b8">&lt;=</td>
+    <td class="tg-b7b8"><code>count shipments by city latitude &lt;= 0</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">=</td>
+    <td class="tg-yw4l">=</td>
+    <td class="tg-yw4l"><code>unique count visitor by store purchased products = 3 for last 5 days</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">!=</td>
+    <td class="tg-b7b8">!=</td>
+    <td class="tg-b7b8"><code>sum sale amount region != canada region != mexico</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-date-de-DE.md
+++ b/_includes/content/keywords-date-de-DE.md
@@ -1,0 +1,355 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-j0ga{background-color:#000000;color:#ffcd33;border-color:inherit;vertical-align:top}
+.tg .tg-dc35{background-color:#f9f9f9;border-color:inherit;vertical-align:top}
+.tg .tg-us36{border-color:inherit;vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-j0ga">Keywords</th>
+    <th class="tg-j0ga">Deutsche</th>
+    <th class="tg-j0ga">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-dc35">after</td>
+    <td class="tg-dc35">nach</td>
+    <td class="tg-dc35"><code>order date after 10/31/2014</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">before</td>
+    <td class="tg-us36">vor</td>
+    <td class="tg-us36"><code>order date before 03/01/2014</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">between … and ...</td>
+    <td class="tg-dc35">zwischen … und ...</td>
+    <td class="tg-dc35"><code>order date between 01/30/2012 and 01/30/2014</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">daily year-over-year</td>
+    <td class="tg-us36">täglich vorjahresvergleich</td>
+    <td class="tg-us36"><code>growth of revenue by order date daily year-over-year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">daily</td>
+    <td class="tg-dc35">täglich</td>
+    <td class="tg-dc35"><code>shipments by region daily</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">day</td>
+    <td class="tg-us36">tag</td>
+    <td class="tg-us36"><code>count monday restaurant</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">day of week</td>
+    <td class="tg-dc35">wochentag</td>
+    <td class="tg-dc35"><code>revenue by day of week last 6 months</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">day of week</td>
+    <td class="tg-us36">wochentag</td>
+    <td class="tg-us36"><code>count shipments Monday</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> days for each month</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> tage für jeden monat</td>
+    <td class="tg-dc35"><code>sales last 2 days for each month</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> days for each quarter</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> tage für jeden quartal</td>
+    <td class="tg-us36"><code>revenue last 15 days for each quarter</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> days for each week</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> tage für jeden woche</td>
+    <td class="tg-dc35"><code>total sold last 2 days for each week</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> days for each year</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> tage für jeden jahr</td>
+    <td class="tg-us36"><code>revenue last 300 days for each year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">growth of … by … daily</td>
+    <td class="tg-dc35">wachstum von … von … täglich</td>
+    <td class="tg-dc35"><code>growth of sales by order date daily</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">growth of … by … monthly</td>
+    <td class="tg-us36">wachstum von … von … monatlich</td>
+    <td class="tg-us36"><code>growth of sales by date shipped monthly sales &gt; 24000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">growth of … by … quarterly</td>
+    <td class="tg-dc35">wachstum von … von … vierteljährlich</td>
+    <td class="tg-dc35"><code>growth of sales by date shipped quarterly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">growth of … by … weekly</td>
+    <td class="tg-us36">wachstum von … von … wöchentlich</td>
+    <td class="tg-us36"><code>growth of sales by receipt date weekly for proski2000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">growth of … by … yearly</td>
+    <td class="tg-dc35">wachstum von … von … jährlich</td>
+    <td class="tg-dc35"><code>growth of sales by date closed yearly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">growth of … by ...</td>
+    <td class="tg-us36">wachstum von … von...</td>
+    <td class="tg-us36"><code>growth of sales by order date</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> hours for each day</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> stündlich für jeden tag</td>
+    <td class="tg-dc35"><code>sales last 2 hours for each day</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">last day by</td>
+    <td class="tg-us36">letzte tag von</td>
+    <td class="tg-us36"><code>customers last day by referrer</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">last month by</td>
+    <td class="tg-dc35">letzte monat von</td>
+    <td class="tg-dc35"><code>customers last month by day</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">last <span style="font-style:italic">n</span> days</td>
+    <td class="tg-us36">letzte <span style="font-style:italic">n</span> tage</td>
+    <td class="tg-us36"><code>visitors last 7 days</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">last <span style="font-style:italic">n</span> quarters</td>
+    <td class="tg-dc35">letzte <span style="font-style:italic">n</span> quartale</td>
+    <td class="tg-dc35"><code>visitors last 2 quarters by month by campaign</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">last <span style="font-style:italic">n</span> weeks</td>
+    <td class="tg-us36">letzte <span style="font-style:italic">n</span> wochen</td>
+    <td class="tg-us36"><code>visitors last 10 weeks by day</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">last quarter</td>
+    <td class="tg-dc35">letzte quartal</td>
+    <td class="tg-dc35"><code>customers last quarter sale &gt;300</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">last week</td>
+    <td class="tg-us36">letzte woche</td>
+    <td class="tg-us36"><code>customers last week by store</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">last year</td>
+    <td class="tg-dc35">letzte jahr</td>
+    <td class="tg-dc35"><code>top 10 customers last year by sale by store for region west</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">month to date</td>
+    <td class="tg-us36">monat bis jetzt</td>
+    <td class="tg-us36"><code>sales by product month to date sales &gt; 2400</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">month year</td>
+    <td class="tg-dc35">monat jahr</td>
+    <td class="tg-dc35"><code>commission by sales rep February 2014</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">month</td>
+    <td class="tg-us36">monat</td>
+    <td class="tg-us36"><code>commission January</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">month</td>
+    <td class="tg-dc35">monat</td>
+    <td class="tg-dc35"><code>revenue by month last year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">monthly year-over-year</td>
+    <td class="tg-us36">monatlich vorjahresvergleich</td>
+    <td class="tg-us36"><code>growth of revenue by receipt date monthly year-over-year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">monthly</td>
+    <td class="tg-dc35">monatlich</td>
+    <td class="tg-dc35"><code>commission &gt; 10000 monthly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> months for each quarter</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> monate für jeden quartal</td>
+    <td class="tg-us36"><code>cost last 2 months for each quarter</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> months for each year</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> monate für jeden jahr</td>
+    <td class="tg-dc35"><code>last 8 months for each year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> days ago</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> tage vor</td>
+    <td class="tg-us36"><code>sales 2 days ago</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> months ago</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> monate vor</td>
+    <td class="tg-dc35"><code>sales 2 months ago by region</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> months</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> monate</td>
+    <td class="tg-us36"><code>visitors last 6 months for homepage visits &gt; 30 by month</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> quarters ago</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> quartale vor</td>
+    <td class="tg-dc35"><code>sales 4 quarters ago by product name contains deluxe</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> weeks ago</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> wochen vor</td>
+    <td class="tg-us36"><code>sales 4 weeks ago by store</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> years ago</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> jahre vor</td>
+    <td class="tg-dc35"><code>sales 5 years ago by store for region west</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> years</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> jahre</td>
+    <td class="tg-us36"><code>opportunities next 5 years by revenue</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> years</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> jahre</td>
+    <td class="tg-dc35"><code>visitors last 5 years by revenue for sum revenue &gt;5000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">next day</td>
+    <td class="tg-us36">nächste tag</td>
+    <td class="tg-us36"><code>shipments next day by order</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">next month</td>
+    <td class="tg-dc35">nächste monat</td>
+    <td class="tg-dc35"><code>appointments next month by day</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">next <span style="font-style:italic">n</span> days</td>
+    <td class="tg-us36">nächste <span style="font-style:italic">n</span> tag</td>
+    <td class="tg-us36"><code>shipments next 7 days</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">next <span style="font-style:italic">n</span> months</td>
+    <td class="tg-dc35">nächste <span style="font-style:italic">n</span> monate</td>
+    <td class="tg-dc35"><code>openings next 6 months location</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">next <span style="font-style:italic">n</span> quarters</td>
+    <td class="tg-us36">nächste <span style="font-style:italic">n</span> quartale</td>
+    <td class="tg-us36"><code>opportunities next 2 quarters by campaign</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">next <span style="font-style:italic">n</span> weeks</td>
+    <td class="tg-dc35">nächste <span style="font-style:italic">n</span> wochen</td>
+    <td class="tg-dc35"><code>shipments next 10 weeks by day</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">next quarter</td>
+    <td class="tg-us36">nächste quartal</td>
+    <td class="tg-us36"><code>opportunities next quarter amount &gt; 30000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">next week</td>
+    <td class="tg-dc35">nächste woche</td>
+    <td class="tg-dc35"><code>shipments next week by store</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">next year</td>
+    <td class="tg-us36">nächste jahr</td>
+    <td class="tg-us36"><code>opportunities next year by sales rep</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">quarter to date</td>
+    <td class="tg-dc35">quartal bis jetzt</td>
+    <td class="tg-dc35"><code>sales by product quarter to date for top 10 products by sales</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">quarterly year-over-year</td>
+    <td class="tg-us36">quartale vorjahresvergleich</td>
+    <td class="tg-us36"><code>growth of revenue by date shipped quarterly year-over-year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">quarterly</td>
+    <td class="tg-dc35">quartale</td>
+    <td class="tg-dc35"><code>sales quarterly for each product</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> quarters for each year</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> quartale für jeden jahr</td>
+    <td class="tg-us36"><code>last 2 quarters for each year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">today</td>
+    <td class="tg-dc35">heute</td>
+    <td class="tg-dc35"><code>sales today by store</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">week to date</td>
+    <td class="tg-us36">woche bis jetzt</td>
+    <td class="tg-us36"><code>sales by order date week to date for pro-ski200</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">week</td>
+    <td class="tg-dc35">woche</td>
+    <td class="tg-dc35"><code>revenue by week last quarter</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">weekly year-over-year</td>
+    <td class="tg-us36">wöchentlich vorjahresvergleich</td>
+    <td class="tg-us36"><code>growth of revenue by date shipped weekly year-over-year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">weekly</td>
+    <td class="tg-dc35">wöchentlich</td>
+    <td class="tg-dc35"><code>revenue weekly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> weeks for each month</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> wochen für jeden monat</td>
+    <td class="tg-us36"><code>sales last 3 weeks for each month</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> weeks for each quarter</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> wochen für jeden quartal</td>
+    <td class="tg-dc35"><code>last 2 weeks for each quarter</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> weeks for each year</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> wochen für jeden jahr</td>
+    <td class="tg-us36"><code>last 3 weeks for each year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">year to date</td>
+    <td class="tg-dc35">jahr bis jetzt</td>
+    <td class="tg-dc35"><code>sales by product year to date</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">year</td>
+    <td class="tg-us36">jahr</td>
+    <td class="tg-us36"><code>revenue by product 2014 product name contains snowboard</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">yearly</td>
+    <td class="tg-dc35">jährlich</td>
+    <td class="tg-dc35"><code>shipments by product yearly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">yesterday</td>
+    <td class="tg-us36">gestern</td>
+    <td class="tg-us36"><code>sales yesterday for pro -ski200 by store</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-date-ja-JP.md
+++ b/_includes/content/keywords-date-ja-JP.md
@@ -1,0 +1,357 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-1r1g{background-color:#fe0000;border-color:inherit;vertical-align:top}
+.tg .tg-dc35{background-color:#f9f9f9;border-color:inherit;vertical-align:top}
+.tg .tg-us36{border-color:inherit;vertical-align:top}
+.tg .tg-lnw8{background-color:#f9f9f9;font-family:serif !important;;border-color:inherit;vertical-align:top}
+.tg .tg-pcxj{background-color:#f9f9f9;border-color:#ffffff;vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-1r1g"><span style="color:rgb(255, 255, 255)">Keywords</span></th>
+    <th class="tg-1r1g"><span style="color:rgb(255, 255, 255)">日本語</span></th>
+    <th class="tg-1r1g"><span style="color:rgb(255, 255, 255)">Examples</span></th>
+  </tr>
+  <tr>
+    <td class="tg-dc35">after</td>
+    <td class="tg-dc35">後</td>
+    <td class="tg-lnw8"><code>order date after 10/31/2014</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">before</td>
+    <td class="tg-us36">前</td>
+    <td class="tg-us36"><code>order date before 03/01/2014</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">between … and ...</td>
+    <td class="tg-dc35">間 … および …</td>
+    <td class="tg-dc35"><code>order date between 01/30/2012 and 01/30/2014</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">daily year-over-year</td>
+    <td class="tg-us36">日単位 前年比</td>
+    <td class="tg-us36"><code>growth of revenue by order date daily year-over-year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">daily</td>
+    <td class="tg-dc35">日単位</td>
+    <td class="tg-dc35"><code>shipments by region daily</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">day</td>
+    <td class="tg-us36">日</td>
+    <td class="tg-us36"><code>count monday restaurant</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">day of week</td>
+    <td class="tg-dc35">曜日</td>
+    <td class="tg-dc35"><code>revenue by day of week last 6 months</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">day of week</td>
+    <td class="tg-us36">曜日</td>
+    <td class="tg-us36"><code>count shipments Monday</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> days for each month</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> 日 それぞれに対して 月</td>
+    <td class="tg-dc35"><code>sales last 2 days for each month</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> days for each quarter</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> 日 それぞれに対して 四半期</td>
+    <td class="tg-us36"><code>revenue last 15 days for each quarter</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> days for each week</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> 日 それぞれに対して 週</td>
+    <td class="tg-dc35"><code>total sold last 2 days for each week</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> days for each year</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> 日 それぞれに対して 年</td>
+    <td class="tg-us36"><code>revenue last 300 days for each year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">growth of … by … daily</td>
+    <td class="tg-dc35">成長…により… 日単位</td>
+    <td class="tg-dc35"><code>growth of sales by order date daily</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">growth of … by … monthly</td>
+    <td class="tg-us36">成長…により… 月単位</td>
+    <td class="tg-us36"><code>growth of sales by date shipped monthly sales &gt; 24000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">growth of … by … quarterly</td>
+    <td class="tg-dc35">成長…により… 四半期単位</td>
+    <td class="tg-dc35"><code>growth of sales by date shipped quarterly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">growth of … by … weekly</td>
+    <td class="tg-us36">成長…により… 週単位</td>
+    <td class="tg-us36"><code>growth of sales by receipt date weekly for proski2000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">growth of … by … yearly</td>
+    <td class="tg-dc35">成長…により… 年単位</td>
+    <td class="tg-dc35"><code>growth of sales by date closed yearly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">growth of … by ...</td>
+    <td class="tg-us36">成長…により…</td>
+    <td class="tg-us36"><code>growth of sales by order date</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> hours for each day</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> 時間単位 それぞれに対して 日</td>
+    <td class="tg-dc35"><code>sales last 2 hours for each day</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">last day by</td>
+    <td class="tg-us36">最後 日 により</td>
+    <td class="tg-us36"><code>customers last day by referrer</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">last month by</td>
+    <td class="tg-dc35">最後 月 により</td>
+    <td class="tg-dc35"><code>customers last month by day</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">last <span style="font-style:italic">n</span> days</td>
+    <td class="tg-us36">最後 n 曜日</td>
+    <td class="tg-us36"><code>visitors last 7 days</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">last <span style="font-style:italic">n</span> quarters</td>
+    <td class="tg-dc35">最後 n 四半期</td>
+    <td class="tg-dc35"><code>visitors last 2 quarters by month by campaign</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">last <span style="font-style:italic">n</span> weeks</td>
+    <td class="tg-us36">最後 n 週</td>
+    <td class="tg-us36"><code>visitors last 10 weeks by day</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">last quarter</td>
+    <td class="tg-dc35">最後 四半期</td>
+    <td class="tg-dc35"><code>customers last quarter sale &gt;300</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">last week</td>
+    <td class="tg-us36">最後 週</td>
+    <td class="tg-us36"><code>customers last week by store</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">last year</td>
+    <td class="tg-dc35">最後 年</td>
+    <td class="tg-dc35"><code>top 10 customers last year by sale by store for region west</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">month to date</td>
+    <td class="tg-us36">月 現在まで</td>
+    <td class="tg-us36"><code>sales by product month to date sales &gt; 2400</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">month year</td>
+    <td class="tg-dc35">月 年</td>
+    <td class="tg-dc35"><code>commission by sales rep February 2014</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">month</td>
+    <td class="tg-us36">月</td>
+    <td class="tg-us36"><code>commission January</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">month</td>
+    <td class="tg-dc35">月</td>
+    <td class="tg-dc35"><code>revenue by month last year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">monthly year-over-year</td>
+    <td class="tg-us36">月単位 前年比</td>
+    <td class="tg-us36"><code>growth of revenue by receipt date monthly year-over-year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">monthly</td>
+    <td class="tg-dc35">月単位</td>
+    <td class="tg-dc35"><code>commission &gt; 10000 monthly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> months for each quarter</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> 月 それぞれに対して 四半期</td>
+    <td class="tg-us36"><code>cost last 2 months for each quarter</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> months for each year</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> 月 それぞれに対して 年</td>
+    <td class="tg-dc35"><code>last 8 months for each year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> days ago</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> 曜日 前</td>
+    <td class="tg-us36"><code>sales 2 days ago</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> months ago</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> 月 前</td>
+    <td class="tg-dc35"><code>sales 2 months ago by region</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> months</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> 月</td>
+    <td class="tg-us36"><code>visitors last 6 months for homepage visits &gt; 30 by month</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> quarters ago</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> 四半期 前</td>
+    <td class="tg-dc35"><code>sales 4 quarters ago by product name contains deluxe</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> weeks ago</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> 週 前</td>
+    <td class="tg-us36"><code>sales 4 weeks ago by store</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> years ago</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> 年 前</td>
+    <td class="tg-dc35"><code>sales 5 years ago by store for region west</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> years</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> 年</td>
+    <td class="tg-us36"><code>opportunities next 5 years by revenue</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> years</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> 年</td>
+    <td class="tg-dc35"><code>visitors last 5 years by revenue for sum revenue &gt;5000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">next day</td>
+    <td class="tg-us36">次 日</td>
+    <td class="tg-us36"><code>shipments next day by order</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">next month</td>
+    <td class="tg-dc35">次 月</td>
+    <td class="tg-dc35"><code>appointments next month by day</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">next <span style="font-style:italic">n</span> days</td>
+    <td class="tg-us36">次 <span style="font-style:italic">n</span> 曜日</td>
+    <td class="tg-us36"><code>shipments next 7 days</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">next <span style="font-style:italic">n</span> months</td>
+    <td class="tg-dc35">次 <span style="font-style:italic">n</span> 月</td>
+    <td class="tg-dc35"><code>openings next 6 months location</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">next <span style="font-style:italic">n</span> quarters</td>
+    <td class="tg-us36">次 <span style="font-style:italic">n</span> 四半期</td>
+    <td class="tg-us36"><code>opportunities next 2 quarters by campaign</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">next <span style="font-style:italic">n</span> weeks</td>
+    <td class="tg-dc35">次 <span style="font-style:italic">n</span> 週</td>
+    <td class="tg-dc35"><code>shipments next 10 weeks by day</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">next quarter</td>
+    <td class="tg-us36">次 四半期</td>
+    <td class="tg-us36"><code>opportunities next quarter amount &gt; 30000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">next week</td>
+    <td class="tg-dc35">次 週</td>
+    <td class="tg-dc35"><code>shipments next week by store</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">next year</td>
+    <td class="tg-us36">次 年</td>
+    <td class="tg-us36"><code>opportunities next year by sales rep</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">quarter to date</td>
+    <td class="tg-dc35">四半期 現在まで</td>
+    <td class="tg-dc35"><code>sales by product quarter to date for top 10 products by sales</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">quarterly year-over-year</td>
+    <td class="tg-us36">四半期単位 前年比</td>
+    <td class="tg-us36"><code>growth of revenue by date shipped quarterly year-over-year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">quarterly</td>
+    <td class="tg-dc35">四半期単位</td>
+    <td class="tg-dc35"><code>sales quarterly for each product</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> quarters for each year</td>
+    <td class="tg-us36"><em>n</em> 四半期 それぞれに対して 年</td>
+    <td class="tg-us36"><code>last 2 quarters for each year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">today</td>
+    <td class="tg-dc35">今日</td>
+    <td class="tg-dc35"><code>sales today by store</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">week to date</td>
+    <td class="tg-us36">週 現在まで</td>
+    <td class="tg-us36"><code>sales by order date week to date for pro-ski200</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">week</td>
+    <td class="tg-dc35">週</td>
+    <td class="tg-dc35"><code>revenue by week last quarter</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">weekly year-over-year</td>
+    <td class="tg-us36">週単位 前年比</td>
+    <td class="tg-us36"><code>growth of revenue by date shipped weekly year-over-year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">weekly</td>
+    <td class="tg-pcxj">週単位</td>
+    <td class="tg-dc35"><code>revenue weekly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> weeks for each month</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> 週 それぞれに対して 月</td>
+    <td class="tg-us36"><code>sales last 3 weeks for each month</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> weeks for each quarter</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> 週 それぞれに対して 四半期</td>
+    <td class="tg-dc35"><code>last 2 weeks for each quarter</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> weeks for each year</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> 週 それぞれに対して 年</td>
+    <td class="tg-us36"><code>last 3 weeks for each year</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">year to date</td>
+    <td class="tg-dc35">年 現在まで</td>
+    <td class="tg-dc35"><code>sales by product year to date</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">year</td>
+    <td class="tg-us36">年</td>
+    <td class="tg-us36"><code>revenue by product 2014 product name contains snowboard</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">yearly</td>
+    <td class="tg-dc35">年単位</td>
+    <td class="tg-dc35"><code>shipments by product yearly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">yesterday</td>
+    <td class="tg-us36">昨日</td>
+    <td class="tg-us36"><code>sales yesterday for pro -ski200 by store</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-general-de-DE.md
+++ b/_includes/content/keywords-general-de-DE.md
@@ -1,0 +1,55 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-31q5{background-color:#000000;color:#ffcd33;vertical-align:top}
+.tg .tg-b7b8{background-color:#f9f9f9;vertical-align:top}
+.tg .tg-yw4l{vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-31q5">Keywords</th>
+    <th class="tg-31q5">Deutsche</th>
+    <th class="tg-31q5">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">top</td>
+    <td class="tg-b7b8">oben</td>
+    <td class="tg-b7b8">
+    <ul><li><code>top sales rep by count sales for average revenue &gt;10000</code></li>
+    <li><code>sales rep average revenue for each region top </code></li> </ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">bottom</td>
+    <td class="tg-yw4l">unten</td>
+    <td class="tg-yw4l">
+    <ul><li><code>bottom revenue average revenue by state</code></li>
+    <li><code>customer by revenue for each sales rep bottom </code></li></ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8"><span style="font-style:italic">n</span></td>
+    <td class="tg-b7b8"><span style="font-style:italic">n</span></td>
+    <td class="tg-b7b8">
+    <code>top 10 sales rep revenue</code>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l"><span style="font-style:italic">n</span></td>
+    <td class="tg-yw4l"><span style="font-style:italic">n</span></td>
+    <td class="tg-yw4l">
+    <code>bottom 25 customer by revenue for each sales rep</code>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">sort by</td>
+    <td class="tg-b7b8">sortieren nach</td>
+    <td class="tg-b7b8">
+    <ul>
+    <li><code>revenue by state sort by average revenue</code></li>
+    <li><code>revenue by customer sort by region</code></li>
+    </ul>
+    </td>
+  </tr>
+</table>

--- a/_includes/content/keywords-general-ja-JP.md
+++ b/_includes/content/keywords-general-ja-JP.md
@@ -1,0 +1,56 @@
+
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-k64o{background-color:#fe0000;color:#ffffff;border-color:inherit;vertical-align:top}
+.tg .tg-dc35{background-color:#f9f9f9;border-color:inherit;vertical-align:top}
+.tg .tg-us36{border-color:inherit;vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-k64o">Keywords</th>
+    <th class="tg-k64o">日本語</th>
+    <th class="tg-k64o">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-dc35">top</td>
+    <td class="tg-dc35">トップ</td>
+    <td class="tg-dc35">
+    <ul><li><code>top sales rep by count sales for average revenue &gt;10000</code></li>
+    <li><code>sales rep average revenue for each region top </code></li> </ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-us36">bottom</td>
+    <td class="tg-us36">ボトム</td>
+    <td class="tg-us36">
+    <ul><li><code>bottom revenue average revenue by state</code></li>
+    <li><code>customer by revenue for each sales rep bottom </code></li></ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><em>n</em></td>
+    <td class="tg-dc35">n</td>
+    <td class="tg-dc35">
+    <code>top 10 sales rep revenue</code>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><em>n</em></td>
+    <td class="tg-us36"><em>n</em></td>
+    <td class="tg-us36">
+    <code>bottom 25 customer by revenue for each sales rep</code>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">sort by</td>
+    <td class="tg-dc35">次で並べ替え</td>
+    <td class="tg-dc35">
+    <ul>
+    <li><code>revenue by state sort by average revenue</code></li>
+    <li><code>revenue by customer sort by region</code></li>
+    </ul>
+    </td>
+  </tr>
+</table>

--- a/_includes/content/keywords-help-de-DE.md
+++ b/_includes/content/keywords-help-de-DE.md
@@ -1,0 +1,25 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-k64o{background-color:#000000;color:#ffcd33;border-color:inherit;vertical-align:top}
+.tg .tg-dc35{background-color:#f9f9f9;border-color:inherit;vertical-align:top}
+.tg .tg-us36{border-color:inherit;vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-k64o">Keywords</th>
+    <th class="tg-k64o">Deutsche</th>
+    <th class="tg-k64o">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-dc35">help</td>
+    <td class="tg-dc35"></td>
+    <td class="tg-dc35"><code>help keywords</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">how to</td>
+    <td class="tg-us36"></td>
+    <td class="tg-us36"><code>how to search</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-help-ja-JP.md
+++ b/_includes/content/keywords-help-ja-JP.md
@@ -1,0 +1,25 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-k64o{background-color:#fe0000;color:#ffffff;border-color:inherit;vertical-align:top}
+.tg .tg-dc35{background-color:#f9f9f9;border-color:inherit;vertical-align:top}
+.tg .tg-us36{border-color:inherit;vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-k64o">Keywords</th>
+    <th class="tg-k64o">日本語</th>
+    <th class="tg-k64o">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-dc35">help</td>
+    <td class="tg-dc35"></td>
+    <td class="tg-dc35"><code>help keywords</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">how to</td>
+    <td class="tg-us36"></td>
+    <td class="tg-us36"><code>how to search</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-location-de-DE.md
+++ b/_includes/content/keywords-location-de-DE.md
@@ -1,0 +1,30 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-31q5{background-color:#000000;color:#ffcd33;vertical-align:top}
+.tg .tg-b7b8{background-color:#f9f9f9;vertical-align:top}
+.tg .tg-yw4l{vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-31q5">Keywords</th>
+    <th class="tg-31q5">Deutsche</th>
+    <th class="tg-31q5">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">near</td>
+    <td class="tg-b7b8">nahe</td>
+    <td class="tg-b7b8"><code>revenue store name county near san francisco</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">near... within n miles|km|meters</td>
+    <td class="tg-yw4l">nahe... innerhalb n meilen|km|meter</td>
+    <td class="tg-yw4l"><code>revenue store name county near alameda within 50 miles</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">farther than n miles|km|meters from</td>
+    <td class="tg-b7b8">entfernter als n meilen|km|meter</td>
+    <td class="tg-b7b8"><code>average hours worked branch farther than 80 km from scarborough</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-location-ja-JP.md
+++ b/_includes/content/keywords-location-ja-JP.md
@@ -1,0 +1,31 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-itju{background-color:#fd6864;color:#ffffff;vertical-align:top}
+.tg .tg-8env{background-color:#fe0000;color:#ffffff;vertical-align:top}
+.tg .tg-b7b8{background-color:#f9f9f9;vertical-align:top}
+.tg .tg-yw4l{vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-8env">Keywords</th>
+    <th class="tg-8env">日本語</th>
+    <th class="tg-8env">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">near</td>
+    <td class="tg-b7b8">近い</td>
+    <td class="tg-b7b8"><code>revenue store name county near san francisco</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">near... within n miles|km|meters</td>
+    <td class="tg-yw4l">近い...以内 n マイル|キロメートル|メートル</td>
+    <td class="tg-yw4l"><code>revenue store name county near alameda within 50 miles</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">farther than n miles|km|meters from</td>
+    <td class="tg-b7b8">以上 n マイル|キロメートル|メートル</td>
+    <td class="tg-b7b8"><code>average hours worked branch farther than 80 km from scarborough</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-number-de-DE.md
+++ b/_includes/content/keywords-number-de-DE.md
@@ -1,0 +1,55 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-31q5{background-color:#000000;color:#ffcd33;vertical-align:top}
+.tg .tg-b7b8{background-color:#f9f9f9;vertical-align:top}
+.tg .tg-yw4l{vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-31q5">Keywords</th>
+    <th class="tg-31q5">Deutsche</th>
+    <th class="tg-31q5">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">sum</td>
+    <td class="tg-b7b8">summe</td>
+    <td class="tg-b7b8"><code>sum revenue</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">average</td>
+    <td class="tg-yw4l">durchschnitt</td>
+    <td class="tg-yw4l"><code>average revenue by store</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">count</td>
+    <td class="tg-b7b8">anzahl</td>
+    <td class="tg-b7b8"><code>count visitors by site</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">max</td>
+    <td class="tg-yw4l">maximum</td>
+    <td class="tg-yw4l"><code>max sales by visitor by site</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">min</td>
+    <td class="tg-b7b8">minimum</td>
+    <td class="tg-b7b8"><code>min revenue by store by campaign for cost &gt; 5000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">standard deviation</td>
+    <td class="tg-yw4l">standardabweichung</td>
+    <td class="tg-yw4l"><code>standard deviation revenue by product by month for date after</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">unique count</td>
+    <td class="tg-b7b8">eindeutige anzahl</td>
+    <td class="tg-b7b8"><code>unique count visitor by product page last week</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">variance</td>
+    <td class="tg-yw4l">varianz</td>
+    <td class="tg-yw4l"><code>variance sale amount by visitor by product for last year</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-number-ja-JP.md
+++ b/_includes/content/keywords-number-ja-JP.md
@@ -1,0 +1,55 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-8env{background-color:#fe0000;color:#ffffff;vertical-align:top}
+.tg .tg-b7b8{background-color:#f9f9f9;vertical-align:top}
+.tg .tg-yw4l{vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-8env">Keywords</th>
+    <th class="tg-8env">日本語</th>
+    <th class="tg-8env">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">sum</td>
+    <td class="tg-b7b8">合計</td>
+    <td class="tg-b7b8"><code>sum revenue</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">average</td>
+    <td class="tg-yw4l">平均</td>
+    <td class="tg-yw4l"><code>average revenue by store</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">count</td>
+    <td class="tg-b7b8">カウント</td>
+    <td class="tg-b7b8"><code>count visitors by site</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">max</td>
+    <td class="tg-yw4l">最大</td>
+    <td class="tg-yw4l"><code>max sales by visitor by site</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">min</td>
+    <td class="tg-b7b8">最小</td>
+    <td class="tg-b7b8"><code>min revenue by store by campaign for cost &gt; 5000</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">standard deviation</td>
+    <td class="tg-yw4l">標準偏差</td>
+    <td class="tg-yw4l"><code>standard deviation revenue by product by month for date after</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">unique count</td>
+    <td class="tg-b7b8">一意のカウント</td>
+    <td class="tg-b7b8"><code>unique count visitor by product page last week</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">variance</td>
+    <td class="tg-yw4l">分散</td>
+    <td class="tg-yw4l"><code>variance sale amount by visitor by product for last year</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-period-de-DE.md
+++ b/_includes/content/keywords-period-de-DE.md
@@ -1,0 +1,75 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-31q5{background-color:#000000;color:#ffcd33;vertical-align:top}
+.tg .tg-b7b8{background-color:#f9f9f9;vertical-align:top}
+.tg .tg-yw4l{vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-31q5">Keywords</th>
+    <th class="tg-31q5">Deutsche</th>
+    <th class="tg-31q5">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">quarter (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8">quartal (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8"><code>quarter (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">quarter of year (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-yw4l">quartal des jahres (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-yw4l"><code>quarter of year (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">month of quarter (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8">monat des quartals (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8"><code>month of quarter (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">week of year (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-yw4l">woche des jahres (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-yw4l"><code>week of year (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">week of quarter (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8">woche des quartals (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8"><code>week of quarter (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">week of month (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-yw4l">woche des monats (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-yw4l"><code>week of month (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">day of year (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8">tag des jahres (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8"><code>day of year (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">day of quarter (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-yw4l">tag des quartals (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-yw4l"><code>day of quarter (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">day (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8">tag (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8"><code>day (order date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">day of month (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-yw4l">tag des monats (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-yw4l"><code>day of monthy (order date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">day of week (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8">wochentag (<span style="font-style:italic">date</span>)</td>
+    <td class="tg-b7b8"><code>day of week (order date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">hour (<span style="font-style:italic">datetime</span>)</td>
+    <td class="tg-yw4l">stunde (datetime)</td>
+    <td class="tg-yw4l"><code>hour (timestamp)</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-period-ja-JP.md
+++ b/_includes/content/keywords-period-ja-JP.md
@@ -1,0 +1,75 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-8env{background-color:#fe0000;color:#ffffff;vertical-align:top}
+.tg .tg-b7b8{background-color:#f9f9f9;vertical-align:top}
+.tg .tg-yw4l{vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-8env">Keywords</th>
+    <th class="tg-8env">日本語</th>
+    <th class="tg-8env">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">quarter (<em>date</em>)</td>
+    <td class="tg-b7b8">四半期 (<em>date</em>)</td>
+    <td class="tg-b7b8"><code>quarter (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">quarter of year (<em>date</em>)</td>
+    <td class="tg-yw4l">年の四半期 (<em>date</em>)</td>
+    <td class="tg-yw4l"><code>quarter of year (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">month of quarter (<em>date</em>)</td>
+    <td class="tg-b7b8">四半期の月 (<em>date</em>)</td>
+    <td class="tg-b7b8"><code>month of quarter (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">week of year (<em>date</em>)</td>
+    <td class="tg-yw4l">年の週 (<em>date</em>)</td>
+    <td class="tg-yw4l"><code>week of year (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">week of quarter (<em>date</em>)</td>
+    <td class="tg-b7b8">四半期の週 (<em>date</em>)</td>
+    <td class="tg-b7b8"><code>week of quarter (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">week of month (<em>date</em>)</td>
+    <td class="tg-yw4l">月の週 (<em>date</em>)</td>
+    <td class="tg-yw4l"><code>week of month (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">day of year (<em>date</em>)</td>
+    <td class="tg-b7b8">年の日付 (<em>date</em>)</td>
+    <td class="tg-b7b8"><code>day of year (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">day of quarter (<em>date</em>)</td>
+    <td class="tg-yw4l">四半期の日付 (<em>date</em>)</td>
+    <td class="tg-yw4l"><code>day of quarter (commit date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">day (<em>date</em>)</td>
+    <td class="tg-b7b8">曜日 (<em>date</em>)</td>
+    <td class="tg-b7b8"><code>day (order date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">day of month (<em>date</em>)</td>
+    <td class="tg-yw4l">月の日付 (<em>date</em>)</td>
+    <td class="tg-yw4l"><code>day of monthy (order date)</code></td>
+  </tr>
+  <tr>
+    <td class="tg-b7b8">day of week (<em>date</em>)</td>
+    <td class="tg-b7b8">曜日 (<em>date</em>)</td>
+    <td class="tg-b7b8"><code>day of week (order date</code></td>
+  </tr>
+  <tr>
+    <td class="tg-yw4l">hour (<em>datetime</em>)</td>
+    <td class="tg-yw4l">時間 (<em>datetime</em>)</td>
+    <td class="tg-yw4l"><code>hour (timestamp)</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-text-de-DE.md
+++ b/_includes/content/keywords-text-de-DE.md
@@ -1,0 +1,54 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-31q5{background-color:#000000;color:#ffcd33;vertical-align:top}
+.tg .tg-4eph{background-color:#f9f9f9}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-31q5">Keywords</th>
+    <th class="tg-31q5">Deutsche</th>
+    <th class="tg-31q5">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-4eph">begins with</td>
+    <td class="tg-4eph">beginnt mit</td>
+    <td class="tg-4eph"><code>product name begins with 'pro'</code></td>
+  </tr>
+  <tr>
+    <td class="tg-031e">contains</td>
+    <td class="tg-031e">enthält</td>
+    <td class="tg-031e"><code>product name contains "alpine" description contains "snow shoe"</code></td>
+  </tr>
+  <tr>
+    <td class="tg-4eph">ends with</td>
+    <td class="tg-4eph">endet mit</td>
+    <td class="tg-4eph"><code>product name ends with 'deluxe'</code></td>
+  </tr>
+  <tr>
+    <td class="tg-031e">not begins with</td>
+    <td class="tg-031e">beginnt nicht mit</td>
+    <td class="tg-031e"><code>product name not begins with "tom's"</code></td>
+  </tr>
+  <tr>
+    <td class="tg-4eph">not contains</td>
+    <td class="tg-4eph">enthält nicht</td>
+    <td class="tg-4eph"><code>product color not contains 'tan' product color not contains 'red'</code></td>
+  </tr>
+  <tr>
+    <td class="tg-031e">not ends with</td>
+    <td class="tg-031e">endet nicht mit</td>
+    <td class="tg-031e"><code>product name not ends with "trial"</code></td>
+  </tr>
+  <tr>
+    <td class="tg-4eph">similar to</td>
+    <td class="tg-4eph">ähnlich zu</td>
+    <td class="tg-4eph"><code>course name similar to 'hand'</code></td>
+  </tr>
+  <tr>
+    <td class="tg-031e">not similar to</td>
+    <td class="tg-031e">nicht ähnlich zu</td>
+    <td class="tg-031e"><code>course name not similar to 'hand'</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-text-ja-JP.md
+++ b/_includes/content/keywords-text-ja-JP.md
@@ -1,0 +1,55 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-k64o{background-color:#fe0000;color:#ffffff;border-color:inherit;vertical-align:top}
+.tg .tg-dc35{background-color:#f9f9f9;border-color:inherit;vertical-align:top}
+.tg .tg-us36{border-color:inherit;vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-k64o">Keywords</th>
+    <th class="tg-k64o">日本語</th>
+    <th class="tg-k64o">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-dc35">begins with</td>
+    <td class="tg-dc35">次で始まる</td>
+    <td class="tg-dc35"><code>product name begins with 'pro'</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">contains</td>
+    <td class="tg-us36">次を含む</td>
+    <td class="tg-us36"><code>product name contains "alpine" description contains "snow shoe"</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">ends with</td>
+    <td class="tg-dc35">次で終了する</td>
+    <td class="tg-dc35"><code>product name ends with 'deluxe'</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">not begins with</td>
+    <td class="tg-us36">次で始まらない</td>
+    <td class="tg-us36"><code>product name not begins with "tom's"</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">not contains</td>
+    <td class="tg-dc35">次を含まない</td>
+    <td class="tg-dc35"><code>product color not contains 'tan' product color not contains 'red'</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">not ends with</td>
+    <td class="tg-us36">次で終了しない</td>
+    <td class="tg-us36"><code>product name not ends with "trial"</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">similar to</td>
+    <td class="tg-dc35">次と類似する</td>
+    <td class="tg-dc35"><code>course name similar to 'hand'</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">not similar to</td>
+    <td class="tg-us36">次と類似しない</td>
+    <td class="tg-us36"><code>course name not similar to 'hand'</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-time-de-DE.md
+++ b/_includes/content/keywords-time-de-DE.md
@@ -1,0 +1,55 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-j0ga{background-color:#000000;color:#ffcd33;border-color:inherit;vertical-align:top}
+.tg .tg-dc35{background-color:#f9f9f9;border-color:inherit;vertical-align:top}
+.tg .tg-us36{border-color:inherit;vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-j0ga">Keywords</th>
+    <th class="tg-j0ga">Deutsche</th>
+    <th class="tg-j0ga">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-dc35">detailed</td>
+    <td class="tg-dc35">detailliert</td>
+    <td class="tg-dc35"><code>ship time detailed</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">last minute</td>
+    <td class="tg-us36">letzte minute</td>
+    <td class="tg-us36"><code>count homepage views last minute</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">last hour</td>
+    <td class="tg-dc35">letzte stunde</td>
+    <td class="tg-dc35"><code>count unique visits last hour</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> minutes</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> minuten</td>
+    <td class="tg-us36"><code>count visitors last 30 minutes</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> hours</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> stunden</td>
+    <td class="tg-dc35"><code>count visitors last 12 hours</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">hourly</td>
+    <td class="tg-us36">stündlich</td>
+    <td class="tg-us36"><code>visitors by page name hourly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> minutes ago</td>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> minuten vor</td>
+    <td class="tg-dc35"><code>sum inventory by product 10 minutes ago</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> hours ago</td>
+    <td class="tg-us36"><span style="font-style:italic">n</span> stunden vor</td>
+    <td class="tg-us36"><code>sum inventory by product by store 2 hours ago</code></td>
+  </tr>
+</table>

--- a/_includes/content/keywords-time-ja-JP.md
+++ b/_includes/content/keywords-time-ja-JP.md
@@ -1,0 +1,57 @@
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;border:none;border-color:#ccc;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;}
+.tg .tg-k64o{background-color:#fe0000;color:#ffffff;border-color:inherit;vertical-align:top}
+.tg .tg-dc35{background-color:#f9f9f9;border-color:inherit;vertical-align:top}
+.tg .tg-us36{border-color:inherit;vertical-align:top}
+.tg .tg-9ryt{background-color:#fe0000;color:#efefef;border-color:inherit;vertical-align:top}
+.tg .tg-wh6h{background-color:#fd6864;color:#ffffff;border-color:inherit;vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-9ryt">Keywords</th>
+    <th class="tg-k64o">日本語</th>
+    <th class="tg-k64o">Examples</th>
+  </tr>
+  <tr>
+    <td class="tg-dc35">detailed</td>
+    <td class="tg-dc35">詳細</td>
+    <td class="tg-dc35"><code>ship time detailed</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">last minute</td>
+    <td class="tg-us36">最後 分</td>
+    <td class="tg-us36"><code>count homepage views last minute</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35">last hour</td>
+    <td class="tg-dc35">最後 時間</td>
+    <td class="tg-dc35"><code>count unique visits last hour</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> minutes</td>
+    <td class="tg-us36"><em>n</em> 分</td>
+    <td class="tg-us36"><code>count visitors last 30 minutes</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n</span> hours</td>
+    <td class="tg-dc35"><em>n</em> 時間</td>
+    <td class="tg-dc35"><code>count visitors last 12 hours</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36">hourly</td>
+    <td class="tg-us36">時間単位</td>
+    <td class="tg-us36"><code>visitors by page name hourly</code></td>
+  </tr>
+  <tr>
+    <td class="tg-dc35"><span style="font-style:italic">n </span>minutes ago</td>
+    <td class="tg-dc35"><em>n</em> 分 前</td>
+    <td class="tg-dc35"><code>sum inventory by product 10 minutes ago</code></td>
+  </tr>
+  <tr>
+    <td class="tg-us36"><span style="font-style:italic">n</span> hours ago</td>
+    <td class="tg-us36"><em>n</em> 時間 前</td>
+    <td class="tg-us36"><code>sum inventory by product by store 2 hours ago</code></td>
+  </tr>
+</table>

--- a/_reference/keywords-de-DE.md
+++ b/_reference/keywords-de-DE.md
@@ -1,0 +1,45 @@
+---
+title: [Deutsche Keyword reference]
+tags: [keywords]
+keywords: tbd
+last_updated: tbd
+sidebar: mydoc_sidebar
+permalink: /:collection/:path.html
+---
+You can use keywords when asking a question to help define your search. This reference lists the various keywords. You can also see this list of keywords and examples from within the help center.
+
+## General
+
+{% include content/keywords-general-de-DE.md %}
+
+## Date
+
+{% include content/keywords-date-de-DE.md %}
+
+## Time
+
+{% include content/keywords-time-de-DE.md %}
+
+## Text
+
+{% include content/keywords-text-de-DE.md %}
+
+## Number
+
+{% include content/keywords-number-de-DE.md %}
+
+## Comparative
+
+{% include content/keywords-comparative-de-DE.md %}
+
+## Location
+
+{% include content/keywords-location-de-DE.md %}
+
+## Period
+
+{% include content/keywords-period-de-DE.md %}
+
+## Help
+
+{% include content/keywords-help-de-DE.md %}

--- a/_reference/keywords-ja-JP.md
+++ b/_reference/keywords-ja-JP.md
@@ -1,0 +1,45 @@
+---
+title: [日本語 Keyword reference]
+tags: [keywords]
+keywords: tbd
+last_updated: tbd
+sidebar: mydoc_sidebar
+permalink: /:collection/:path.html
+---
+You can use keywords when asking a question to help define your search. This reference lists the various keywords. You can also see this list of keywords and examples from within the help center.
+
+## General
+
+{% include content/keywords-general-ja-JP.md %}
+
+## Date
+
+{% include content/keywords-date-ja-JP.md %}
+
+## Time
+
+{% include content/keywords-time-ja-JP.md %}
+
+## Text
+
+{% include content/keywords-text-ja-JP.md %}
+
+## Number
+
+{% include content/keywords-number-ja-JP.md %}
+
+## Comparative
+
+{% include content/keywords-comparative-ja-JP.md %}
+
+## Location
+
+{% include content/keywords-location-ja-JP.md %}
+
+## Period
+
+{% include content/keywords-period-ja-JP.md %}
+
+## Help
+
+{% include content/keywords-help-ja-JP.md %}

--- a/_reference/keywords.md
+++ b/_reference/keywords.md
@@ -6,7 +6,9 @@ last_updated: tbd
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-You can use keywords when asking a question to help define your search. This reference lists the various keywords. You can also see this list of keywords and examples from within the help center.
+You can use keywords when asking a question to help define your search. This
+reference lists the various keywords. You can also see this list of keywords and
+examples from within the help center.
 
 
 ## General


### PR DESCRIPTION
### What's changed

- Markdown source for Japanese and German keywords

### Related
[SCAL-24868](https://thoughtspot.atlassian.net/browse/SCAL-24868)

cc: @aliciaavrach


Signed-off-by: Victoria Bialas <vicky@thoughtspot.com>