### PR TITLE
Fixed reading time to apply to all appropriate pages

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -36,6 +36,10 @@ layout: default
 
     {% unless page.toc == false %}
     {% include toc.html %}
+    {% endunless %}
+
+
+    {% unless page.tree == false %}
     {% include read_time.html %}
     {% endunless %}
 


### PR DESCRIPTION
### What's changed

- In the `page.html` layouts definition, moved the `reading time` conditional statement out of the on-page TOC condition so that it applies to all pages

### Related

- PRs #232 , #231 , #230 , and so on

Signed-off-by: Victoria Bialas <vicky@thoughtspot.com>