### PR TITLE
fixing a jekyll serve problem related to Gemfile versions 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ require 'json'
 require 'open-uri'
 versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
-gem 'github-pages', versions['github-pages']
+# gem 'github-pages', versions['github-pages']
+gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll-sitemap'
 gem 'jekyll-seo-tag'
 gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
-    octokit (4.10.0)
+    octokit (4.11.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
@@ -219,7 +219,7 @@ GEM
     ruby-enum (0.7.2)
       i18n
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
@@ -242,7 +242,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (= 191)
+  github-pages
   jekyll-redirect-from
   jekyll-seo-tag
   jekyll-sitemap


### PR DESCRIPTION
The Gemfile line that referenced github pages versions was preventing local use of `bundle exec jekyll serve` and any other bundle commands like `bundle install` or `bundle update.

I commented out that line and used github pages and jekyll plugins instead, as shown in Tom's documentation theme Gemfile (upon which our docs are based).

This seems to have fixed the problem, we can now use jekyll for local builds with seemingly no other negative impact, and all `bundle` commands work again.

Signed-off-by: Victoria Bialas <vicky@thoughtspot.com>