### PR TITLE
clarified --has_header_row desc in tsload flag ref

### DIFF
--- a/_reference/data-importer-ref.md
+++ b/_reference/data-importer-ref.md
@@ -137,7 +137,7 @@ The following flags are used when loading data from an input file:
     <tr>
       <td><code class="highlighter-rouge">--has_header_row</code></td>
       <td>Indicates that the input file contains a header row.</td>
-      <td>If supplied, column names in the header row are are used to match column names in the target table in ThoughtSpot. If not supplied, the first row of the file is loaded as data, the same as all subsequent rows.</td>
+      <td>If supplied, column names in the header row are used to match column names in the target table in ThoughtSpot. If not supplied, the first row of the file is loaded as data, the same as all subsequent rows.</td>
     </tr>
     <tr>
       <td><code class="highlighter-rouge">--escape_character "&lt;character&gt;"</code></td>


### PR DESCRIPTION

### What's changed

Re-wrote description of `-has_header_row` per these review comments from Eric Musser: 

"It says the first row of the file is ignored, but it actually uses the header row to match up columns of the csv to the columns of the table being inserted into."


Signed-off-by: Victoria Bialas <vicky@thoughtspot.com>