### PR TITLE
formulas reference: added fiscal/calendar date functions, group_aggregate

### DIFF
--- a/_includes/content/aggregate.md
+++ b/_includes/content/aggregate.md
@@ -54,6 +54,27 @@
       <td><code class="highlighter-rouge">cumulative_sum (revenue, order date)</code></td>
     </tr>
     <tr>
+      <td><code>group_aggregate</code></td>
+      <td>
+      Takes a measure and, optionally, attributes and filters. These can be used
+      to aggregate measures with granularities and filters different from the
+      terms/columns used in the search. Especially useful for comparison
+      analysis. <br /><br />
+      This formula takes the form:
+      group_aggregate (< aggregation (measure) >, < groupings >, < filters >)<br /><br />
+      Lists can be defined with {} and
+      optional list functions <code class="highlighter-rouge">query_groups</code> or
+      <code class="highlighter-rouge">query_filters</code>, which by default
+      specify the lists or filters used in the original search. Plus (+) or (-)
+      can be used to add or exclude specific columns for query groups.
+      </td>
+      <td><code class="highlighter-rouge">group_aggregate (sum (revenue) , {ship mode, date} , {} )</code><br /><br />
+      <code class="highlighter-rouge" >group_aggregate (sum (revenue) , {ship mode , date}, {day_of_week (date) = 'friday'} )</code><br /><br />
+      <code class="highlighter-rouge">group_aggregate (sum (revenue) , query_groups() , query_filters() )</code><br /><br />
+      <code class="highlighter-rouge">group_aggregate (sum (revenue) , query_groups() + {date} , query_filters() )</code>
+      </td>
+    </tr>
+    <tr>
       <td><code>group_average</code></td>
       <td>Takes a measure and one or more attributes. Returns the average of the measure grouped by the attribute(s).</td>
       <td><code class="highlighter-rouge">group_average (revenue, customer region, state)</code></td>

--- a/_includes/content/date-func.md
+++ b/_includes/content/date-func.md
@@ -28,24 +28,36 @@
       <td><code class="highlighter-rouge">day (01/15/2014) = 15</code><br><code class="highlighter-rouge">day (date ordered)</code></td>
     </tr>
     <tr>
-      <td><code>day_number_of_week</code></td>
-      <td>Returns the number (1-7) of the day in a week for the given date with 1 being Monday and 7 being Sunday.</td>
-      <td><code class="highlighter-rouge">day_number_of_week (01/30/2015) = 6</code><br><code class="highlighter-rouge">day_number_of_week (shipped)</code></td>
-    </tr>
-    <tr>
        <td><code>day_number_of_quarter</code></td>
-       <td>Returns the number of the day in a quarter for a given date.</td>
-       <td><code class="highlighter-rouge">day_number_of_quarter (01/30/2015)</code></td>
+       <td>
+        Returns the number of the day in a quarter for a given date. Add an optional
+        second parameter to specify whether a 'fiscal' or 'calendar' year is used to
+        calculate the result. Default is 'calendar'. (In examples, start of fiscal year
+        is set to May 01.)
+       </td>
+       <td>
+       <code class="highlighter-rouge">day_number_of_quarter (01/30/2015) = 30</code><br>
+       <code class="highlighter-rouge">day_number_of_quarter (01/30/2015, 'fiscal') = 91</code><br>
+       </td>
     </tr>
     <tr>
        <td><code>day_number_of_week</code></td>
-        <td>Returns the number of the day in a week for a given date.</td>
-       <td><code class="highlighter-rouge">day_number_of_week(01/15/2014) > 3</code></td>
+        <td>Returns the number (1-7) of the day in a week for a given date with 1 being Monday and 7 being Sunday.</td>
+       <td><code class="highlighter-rouge">day_number_of_week(01/15/2014)  3</code><br>
+       <code class="highlighter-rouge">day_number_of_week (shipped)</code><br>
+       </td>
     </tr>
     <tr>
       <td><code>day_number_of_year</code></td>
-      <td>Returns the number (1-366) of the day in a year for the given date.</td>
-      <td><code class="highlighter-rouge">day_number_of_year (01/30/2015) = 30</code><br><code class="highlighter-rouge">day_number_of_year (invoiced)</code></td>
+      <td>
+      Returns the number (1-366) of the day in a year from a given date. Add an
+      optional second parameter to specify whether a 'fiscal' or 'calendar' year is
+      used to calculate the result. Default is 'calendar'. (In examples, start of
+      fiscal year is set to May 01.)
+      </td>
+      <td><code class="highlighter-rouge">day_number_of_year (01/30/2015) = 30</code><br>
+      <code class="highlighter-rouge">day_number_of_year ( 01/30/2015, 'fiscal' ) = 275</code><br>
+      <code class="highlighter-rouge">day_number_of_year (invoiced)</code></td>
     </tr>
     <tr>
       <td><code>day_of_week</code></td>
@@ -79,18 +91,42 @@
     </tr>
     <tr>
       <td><code>month_number</code></td>
-      <td>Returns the number (1-12) of the month for the given date.</td>
-      <td><code class="highlighter-rouge">month_number (09/20/2014) = 9</code><br><code class="highlighter-rouge">month_number (purchased)</code></td>
+      <td>
+        Returns the number (1-12) of the month from a given date. Add an optional second
+        parameter to specify whether a 'fiscal' or 'calendar' year is used to calculate
+        the result. Default is 'calendar'. (In examples, start of fiscal year is set to
+        May 01.)
+      </td>
+      <td><code class="highlighter-rouge">month_number (09/20/2014) = 9</code><br>
+      <code class="highlighter-rouge">month_number ( 09/20/2014, 'fiscal' ) = 5</code><br>
+      <code class="highlighter-rouge">month_number (purchased)</code></td>
     </tr>
     <tr>
        <td><code>month_number_of_quarter</code></td>
-       <td>Returns the month (1-12) number for the given date in a quarter.</td>
-       <td><code class="highlighter-rouge">month_number_of_quarter (02/20/2018) > 9 </code></td>
+       <td>
+        Returns the month (1-12) number for the given date in a quarter. Add an optional
+        second parameter to specify whether a 'fiscal' or 'calendar' year is used to
+        calculate the result. Default is 'calendar'. (In examples, start of fiscal year
+        is set to May 01.)
+       </td>
+       <td><code class="highlighter-rouge">month_number_of_quarter (02/20/2018) = 9 </code><br>
+       <code class="highlighter-rouge">month_number_of_quarter (02/20/2018,'fiscal' ) = 1</code></td>
     </tr>
     <tr>
       <td><code>now</code></td>
       <td>Returns the current timestamp.</td>
       <td><code class="highlighter-rouge">now ()</code></td>
+    </tr>
+    <tr>
+       <td><code>quarter_number</code></td>
+       <td>
+        Returns the number (1-4) of the quarter associated with the given date. Add an
+        optional second parameter to specify 'fiscal' or 'calendar' dates. Default is
+        'calendar'. (In examples, start of fiscal year is set to May 01.)
+       </td>
+       <td><code class="highlighter-rouge">quarter_number ( 04/14/2014) = 2 </code><br>
+       <code class="highlighter-rouge">quarter_number ( 04/14/2014, 'fiscal' ) = 4</code><br>
+       <code class="highlighter-rouge">quarter_number ( shipped )</code></td>
     </tr>
     <tr>
       <td><code>start_of_month</code></td>
@@ -99,8 +135,15 @@
     </tr>
     <tr>
       <td><code>start_of_quarter</code></td>
-      <td>Returns the date for the first day of the quarter for the given date.</td>
-      <td><code class="highlighter-rouge">start_of_quarter ( 09/18/2015 ) = Q3 FY 2015</code><br><code class="highlighter-rouge">start_of_quarter (sold)</code></td>
+      <td>
+      Returns the date for the first day of the quarter for the given date. Add an
+      optional second parameter to specify whether a 'fiscal' or 'calendar' year is
+      used to calculate the result. Default is 'calendar'. (In examples, start of
+      fiscal year is set to May 01.)
+      </td>
+      <td><code class="highlighter-rouge">start_of_quarter ( 04/01/2014) = Apr 2014</code><br>
+      <code class="highlighter-rouge">start_of_quarter ( 04/01/2014, 'fiscal') = Feb 2014</code><br>
+      <code class="highlighter-rouge">start_of_quarter (sold)</code></td>
     </tr>
     <tr>
       <td><code>start_of_week</code></td>
@@ -109,8 +152,16 @@
     </tr>
     <tr>
       <td><code>start_of_year</code></td>
-      <td>Returns the date for the first day of the year for the given date.</td>
-      <td><code class="highlighter-rouge">start_of_year ( 02/15/2015 ) = FY 2015</code><br><code class="highlighter-rouge">start_of_year (joined)</code></td>
+      <td>
+      Returns the date for the first day of the year for the given date. Add an
+      optional second parameter to specify whether a 'fiscal' or 'calendar' year is
+      used to calculate the result. Default is 'calendar'. (In examples, start of
+      fiscal year is set to May 01.)
+      </td>
+      <td>
+      <code class="highlighter-rouge">start_of_year (04/01/2014) returns Jan 2014</code><br>
+      <code class="highlighter-rouge">start_of_year (04/01/2014, 'fiscal') returns May 2013</code><br>
+      <code class="highlighter-rouge">start_of_year (joined)</code></td>
     </tr>
     <tr>
       <td><code>time</code></td>
@@ -124,13 +175,27 @@
     </tr>
     <tr>
        <td><code>week_number_of_quarter</code></td>
-       <td>Returns the week number for the given date in a quarter.</td>
-       <td><code class="highlighter-rouge">week_number_of_quarter(04/03/2017)> 2 </code></td>
+       <td>
+        Returns the week number for the given date in a quarter. Add an optional second
+        parameter to specify whether a 'fiscal' or 'calendar' year is used to calculate
+        the result. Default is 'calendar'. (In examples, start of fiscal year is set to
+        May 01.)
+       </td>
+       <td><code class="highlighter-rouge">week_number_of_quarter (04/03/2017) = 1</code><br>
+       <code class="highlighter-rouge">week_number_of_quarter (04/03/2017, 'fiscal') = 10</code></td>
     </tr>
     <tr>
        <td><code>week_number_of_year</code></td>
-       <td>Returns the week number for the given date in a year.</td>
-       <td><code class="highlighter-rouge">week_number_of_year(04/03/2017) = 20 </code></td>
+       <td>
+        Returns the week number for the given date in a year. Add an optional second
+        parameter to specify whether a 'fiscal' or 'calendar' year is used to calculate
+        the result. Default is 'calendar'. (In examples, start of fiscal year is set to
+        May 01.)
+       </td>
+       <td>
+       <code class="highlighter-rouge">week_number_of_year (01/17/2014) = 3</code><br>
+       <code class="highlighter-rouge">week_number_of_year ( 01/17/2014, 'fiscal') = 38</code>
+       </td>
     </tr>
     <tr>
       <td><code>year</code></td>

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -629,7 +629,7 @@ table.dataTable thead {
     background-color: #444;
 }
 table td {
-    hyphens: auto;
+    hyphens: none;
 }
 
 section table tr.success {


### PR DESCRIPTION
### What's new

Updated formulas reference to match updates to Formula Assistant for v5.0, including:
- fiscal, calendar date functions
- group aggregate functions
- added missing functions (quarter_number, month_number)
- made corrections to some examples in formulas reference 

### Related
SCAL-26880
SCAL-30451
SCAL-24602
SCAL-22856
SCAL-25046

Signed-off-by: Victoria Bialas <vicky@thoughtspot.com>