### PR TITLE
updated month_number_of_quarter description to match Formula Assistant

### DIFF
--- a/_includes/content/date-func.md
+++ b/_includes/content/date-func.md
@@ -104,7 +104,7 @@
     <tr>
        <td><code>month_number_of_quarter</code></td>
        <td>
-        Returns the month (1-12) number for the given date in a quarter. Add an optional
+        Returns the month (1-3) number for the given date in a quarter. Add an optional
         second parameter to specify whether a 'fiscal' or 'calendar' year is used to
         calculate the result. Default is 'calendar'. (In examples, start of fiscal year
         is set to May 01.)


### PR DESCRIPTION
### What's changed

Updated description for `month_number_of_quarter` which had incorrrectly mentioned months (1-12), should be (1-3) per Ajay's review of same description in Formula Assistant strings.  

Signed-off-by: Victoria Bialas <vicky@thoughtspot.com>