### PR TITLE
Updated locale.html (Removed the Warning msg)

### DIFF
--- a/5.0/end-user/locale.html
+++ b/5.0/end-user/locale.html
@@ -3136,10 +3136,6 @@ inputted.</p>
 should look like this: <code class="highlighter-rouge">xxx,xxx.xx</code>. And in Europe, it should look like this:
 <code class="highlighter-rouge">xxx.xxx,xx</code>.</p>
 
-<div class="alert alert-danger" role="alert"><i class="fa fa-exclamation-circle"></i> <b>Warning:</b> It is possible that you set your locale but
-find strings in the UI still appear in English, this indicates an untranslated
-string. Please notify ThoughtSpot support.</div>
-
 
   <div class="tags">
     <div style="float:right;">


### PR DESCRIPTION
Removed the following:

 Warning: It is possible that you set your locale but find strings in the UI still appear in English, this indicates an untranslated string. Please notify ThoughtSpot support.