### PR TITLE
css line spacing home page, remove 3.4 version menu from source

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -24,5 +24,3 @@ topnav_dropdowns:
           url: /4.2/4.2-home.html
         - title: 3.5
           url: /3.5/3.5-home.html
-        - title: 3.4
-          url: /3.4/3.4-home.html

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -62,6 +62,7 @@ p.bookLink {
   font-family: sans-serif;
 /*  line-height: 80%; */
   margin-top:-10px;
+  padding-top: 10px;
 }
 
 img.indexImg {


### PR DESCRIPTION
* added top padding to `booklink` CSS style for home page
* removed `3.4` version menu from `topnav.html` in source so hopefully it won't keep coming back when we regenerate HTML in master (needs to be done on `4.5` also)

@aliciaavrach 
Signed-off-by: Victoria Bialas <vicky@thoughtspot.com>