### PR TITLE
removed 3.4 version menu from 4.5 source

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -22,5 +22,3 @@ topnav_dropdowns:
           url: /4.2/4.2-home.html
         - title: 3.5
           url: /3.5/3.5-home.html
-        - title: 3.4
-          url: /3.4/3.4-home.html


### PR DESCRIPTION
* Fixing this in source so that it won't keep showing up when we regenerate `4.5` HTML
* Similar fix was done for `5.0` in PR #375 

Signed-off-by: Victoria Bialas <vicky@thoughtspot.com>