### PR TITLE
Updated formatting text in the "Finding your way around" and "ThoughtSpot browser access" topics 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (~> 3.0)
-    json (1.8.3)
+    json (1.8.3.1)
     kramdown (1.17.0)
     liquid (4.0.0)
     listen (3.1.5)
@@ -250,4 +250,4 @@ DEPENDENCIES
   json
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/_end-user/introduction/about-navigating-thoughtspot.md
+++ b/_end-user/introduction/about-navigating-thoughtspot.md
@@ -33,6 +33,7 @@ home page is a search bar and below that several areas that show activity in you
     <td>
     Shows all time popular answers and pinboards by number of views. You can
     choose between all-time popular or recently in the last 15 days. Small icons illustrate the type of visualization you'll find when you click on an item.
+    <br>
     <img src="{{ "/images/home-trending.png "| prepend: site.baseurl  }}" />
 </td>
   </tr>

--- a/_includes/content/log_in_out.md
+++ b/_includes/content/log_in_out.md
@@ -49,9 +49,9 @@ The following browsers are verified to work well with the ThoughtSpot applicatio
 not recommended. Depending on your environment, you can experience performance
 or UI issues when using IE." %}
 
-## Log in
+## Sign in
 
-To log in to ThoughtSpot from a browser:
+To sign in to ThoughtSpot from a browser:
 
 1. Open the browser and type in the Web address for ThoughtSpot: `http://HOSTNAME_OR_IP`
 2. Enter your username and password and click **Sign In**.
@@ -59,9 +59,9 @@ To log in to ThoughtSpot from a browser:
    ![]({{ site.baseurl }}/images/log_in.png "Log in")
 
 
-## Log out
+## Sign out
 
-Once you're done with your search session, you can optionally log out of
+Once you're done with your search session, you can optionally sign out of
 ThoughtSpot. To log out of ThoughtSpot from a browser:
 
 1. Click your user icon at the top right hand corner of the screen.


### PR DESCRIPTION
Updated formatting in the Finding your way around topic and changed ThoughtSpot browser access topic to use Sign In and Sign Out instead of Log In and Log Out

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>