### PR TITLE
Updated launch-an-instance.md

### DIFF
--- a/_appliance/aws/launch-an-instance.md
+++ b/_appliance/aws/launch-an-instance.md
@@ -16,11 +16,11 @@ The ThoughtSpot AMI comes provisioned with the custom ThoughtSpot image to make 
 -   A template for the root volume for the instance (for example, an operating system, an appliance server, and applications).
 -   Launch permissions that control which AWS accounts can use the AMI to launch instances.
 
--   A block device mapping that specifics the volumes to attach to the instance when it's launch.
+-   A block device mapping that specifies the volumes to attach to the instance when it's launch.
 
 Check with your ThoughtSpot contact to learn about the latest version of the ThoughtSpot AMI. Once you've provided your AWS account ID and region where the VMs will be hosted, ThoughtSpot will share the current ThoughtSpot base AMI with you.
 
-The ThoughtSpot AMI has specific applications on an CentOS base image. The EBS volumes required for ThoughtSpot install in AWS comes as part of the AMI. When you launch an EC2 instance from this image, the EBS volumes automatically get sized and provisioned. The storage attached to the base AMI is 200 GB (xvda), 2X400 GB (xvdb), and SSD gp2. It contains the max disks so that it can take care of the full load of the VM.
+The ThoughtSpot AMI has specific applications on an CentOS base image. The EBS volumes required for ThoughtSpot install in AWS comes as part of the AMI. When you launch an EC2 instance from this image, the EBS volumes automatically get sized and provisioned. The storage attached to the base AMI is 200 GB (xvda), 2X1 TB (xvdb), and SSD gp2. It contains the max disks so that it can take care of the full load of the VM.
 
 ##  Launch an instance
 


### PR DESCRIPTION
Updated the following:

A block device mapping that specifies the volumes to attach to the instance when it’s launched
The storage attached to the base AMI is 200 GB (xvda), 2X1 TB (xvdb), and SSD gp2.