### PR TITLE
Update launch-an-instance.md

### DIFF
--- a/_appliance/gcp/launch-an-instance.md
+++ b/_appliance/gcp/launch-an-instance.md
@@ -111,7 +111,7 @@ with your ThoughtSpot Customer Service or Support Engineer on these steps." %}
 Before we can install a ThoughtSpot cluster, an administrator must log in to
 each VM via SSH and complete the following preparation steps:
 
-1. Run `/usr/local/scaligent/release/bin/prepare_disks.sh` on every machine.
+1. Run `/usr/local/scaligent/bin/prepare_disks.sh` on every machine.
 2. Configure each VM based on the site-survey.
 
 ## Launch the cluster


### PR DESCRIPTION
For GCP boot disk image, correct path prepare_disks.sh is /usr/local/scaligent/bin/prepare_disks.sh and not /usr/local/scaligent/release/bin/prepare_disks.sh