### PR TITLE
SCAL-35267 updated tscli firewall open-ports command description

### DIFF
--- a/_admin/setup/slack-integration.md
+++ b/_admin/setup/slack-integration.md
@@ -26,3 +26,9 @@ Here are the high level steps:
 4. Start Spot Bot.
 5. Register Spot bot with your company's Slack instance.
 6. Register your Spot Slack account to ThoughtSpot.
+
+## Related Information
+
+Relevant `tscli` commands are [here]({{ site.baseurl }}/reference/tscli-command-ref.html#spot), but these will not work until Spot is enabled by ThoughtSpot Support. Support
+will work with you to install Spot, and then provide the rest of the workflow to
+you, including `tscli` command usage.

--- a/_end-user/slack/intro.md
+++ b/_end-user/slack/intro.md
@@ -22,7 +22,12 @@ integration, mention <strong>&#64;spot</strong> and see if he barks back:
 
 In this particular channel, <strong>&#64;spot</strong> is there for you but like
 his brothers <strong>&#64;spot-east-credit</strong> is not in the channel.
-Scroll down to Frequently asked questions to get started with Spot.
 
 If <strong>&#64;spot</strong> doesn’t come when you “call” you are spotless. Ask your
 administrator to see if you can get one.
+
+## Related Information
+
+* Go to [How to use Spot](use-spot.md) to get started using Spot.
+
+* For information on setting up Spot, see [Slack Integration]({{ site.baseurl }}/admin/setup/slack-integration.html) in the Administration Guide.

--- a/_end-user/slack/intro.md
+++ b/_end-user/slack/intro.md
@@ -28,6 +28,6 @@ administrator to see if you can get one.
 
 ## Related Information
 
-* Go to [How to use Spot](use-spot.md) to get started using Spot.
+* Go to [How to use Spot](use-spot.html) to get started using Spot.
 
 * For information on setting up Spot, see [Slack Integration]({{ site.baseurl }}/admin/setup/slack-integration.html) in the Administration Guide.

--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -352,7 +352,7 @@ tscli firewall [-h] {close-ports,disable,enable,open-ports,status} ...
 
 * `tscli firewall disable` Disable firewall.
 * `tscli firewall enable` Enable firewall.
-* `tscli firewall open-ports` *`ports`*
+* `tscli firewall open-ports` `--ports`  *`ports`*
 
    Opens given ports through firewall on all nodes. Takes a list of ports to
    open, comma separated. Ignores ports which are already open. Some essential


### PR DESCRIPTION
* corrected `tscli` firewally open-ports command per @kmfort 
* added some x-refs for Slack and Spot per David Hu (totally unrelated, just sneaking it in)


Signed-off-by: Victoria Bialas <vicky@thoughtspot.com>

cc: @kmfort 