### PR TITLE
Active Directory based access topics for 5.1

### DIFF
--- a/_admin/setup/active-directory-based-access.md
+++ b/_admin/setup/active-directory-based-access.md
@@ -1,0 +1,58 @@
+---
+title: [Enable Active Directory based access]
+tags: []
+keywords: "active directory"
+last_updated: tbd
+summary: "ThoughtSpot supports enabling Active Directory (AD) based access individually on each node where the commands are run. "
+sidebar: mydoc_sidebar
+permalink: /:collection/:path.html
+---
+
+## Enable Active Directory based access on a ThoughtSpot node
+
+ThoughtSpot supports enabling Active Directory (AD) based access individually on
+each node where the commands are run. There is no provision to enable AD access
+for the whole cluster with a single command. To enable AD access on a cluster,
+you need to run these commands on each individual node and on any additional
+nodes added to the cluster.
+
+The command to enable system AD user access is:
+
+```
+tscli sssd enable --user <USER> --domain <DOMAIN>
+```
+
+You will then be prompted for password credentials.
+
+{% include note.html content="The user must have permission to join a computer or VM to the domain."%}
+
+## Set sudoers AD Group on a local node
+
+Just like enabling AD based access on a node, setting `sudo` AD group applies
+only on the node where the command is run, and is not set for the whole cluster.
+
+The command to allow `sudo` permissions for AD group:
+
+```
+tscli sssd set-sudo-group <ACTIVE_DIRECTORY_GROUP_NAME>
+```
+
+## Disable Active Directory based access on a local node
+
+Currently ThoughtSpot supports disabling AD based access individually on each
+node where the commands are run. There is no provision to disable AD access for
+the whole cluster with a single command. To disable AD access on a cluster,  run
+these commands on each individual node and any additional nodes added to the
+cluster.
+
+Command to disable system AD user access is:
+
+```
+tscli sssd disable
+```
+
+{% include note.html content="Running this command will also remove the AD group from sudoers list."%}
+
+## Related Information
+
+* [sssd]({{ site.baseurl }}/reference/tscli-command-ref.html#sssd) in the `tscli` command reference

--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -445,6 +445,9 @@ entries:
       - title: Configure SAML
         url: /admin/setup/configure-SAML-with-tscli.html
         output: web,admBk
+      - title: Enable Active Directory based access
+        url: /admin/setup/active-directory-based-access.html
+        output: web,admBk
       - levelThreeTitle: Integrate LDAP
         output: web,admBk
         levelThreeItems:

--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -864,6 +864,32 @@ This subcommand supports the following actions:
 * `tscli ssl tls-status [-h]`  Prints the status of TLS support.
 
 
+### sssd
+
+```
+tscli sssd {enable, set-sudo-group, disable} ...
+```
+
+This subcommand uses system security services daemon (SSSD), and has the following actions:
+
+* `tscli sssd enable --user` *`USER`* `--domain` *`DOMAIN`*
+
+   Enables system Active Directory (AD) user access on a single node. You will be
+   prompted for password credentials. The user must have permission to join a
+   computer or VM to the domain.
+
+* `tscli sssd set-sudo-group` *`ACTIVE_DIRECTORY_GROUP_NAME`*
+
+   Allows `sudo` permissions for AD group
+
+* `tscli sssd disable`
+
+   Disables system AD based access on a local node.
+
+   {% include note.html content="Running this command will also remove the AD group from sudoers list."%}
+
+For more about setting up Active Directory access, see [Enable Active Directory based access]({{ site.baseurl }}/admin/setup/active-directory-based-access.html).
+
 ### storage
 
 ```


### PR DESCRIPTION
### What's changed

- new Admin Guide topic on enabling AD based access
- new subcommand added to `tscli` command reference
- x-refs

### Related 

Link to PM documentation that these topics are based on: [System AD Based Access Usage Documentation](https://docs.google.com/document/d/1pG2tG1NWJjka9_-P-A6gaju8gI4rXrejnwz370T9u1c/edit?usp=sharing)

 [Jira SCAL-32685](https://thoughtspot.atlassian.net/browse/SCAL-32685)

cc: @puchki-chat07 

Signed-off-by: Victoria Bialas <vicky@thoughtspot.com>