### PR TITLE
Kevin's review comments on AD based access to TS

### DIFF
--- a/_admin/setup/active-directory-based-access.md
+++ b/_admin/setup/active-directory-based-access.md
@@ -37,7 +37,18 @@ The command to allow `sudo` permissions for AD group:
 tscli sssd set-sudo-group <ACTIVE_DIRECTORY_GROUP_NAME>
 ```
 
-## Disable Active Directory based access on a local node
+## Clear sudoers AD Group on a local node
+
+Clearing `sudo` AD group only applies on the node where command is run, and is
+not set for the whole cluster.
+
+The command to clear `sudo` permissions for the AD group:
+
+```
+tscli sssd clear-sudo-group <ACTIVE_DIRECTORY_GROUP_NAME>
+```
+
+## Disable AD based access on a local node
 
 Currently ThoughtSpot supports disabling AD based access individually on each
 node where the commands are run. There is no provision to disable AD access for

--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -840,32 +840,6 @@ Enables Spot integration.  This subcommand supports the following actions:
 * `--thoughtspot_url` *`THOUGHTSPOT_URL`* URL for the ThoughtSpot application. This is required.
 * `--cache_timeout` *`CACHE_TIMEOUT`*  Internal cache timeout (default: `60000`)
 
-### sssd
-
-```
-tscli sssd {enable, set-sudo-group, disable} ...
-```
-
-This subcommand uses system security services daemon (SSSD), and has the following actions:
-
-* `tscli sssd enable --user` *`USER`* `--domain` *`DOMAIN`*
-
-   Enables system Active Directory (AD) user access on a single node. You will be
-   prompted for password credentials. The user must have permission to join a
-   computer or VM to the domain.
-
-* `tscli sssd set-sudo-group` *`ACTIVE_DIRECTORY_GROUP_NAME`*
-
-   Allows `sudo` permissions for AD group
-
-* `tscli sssd disable`
-
-   Disables system AD based access on a local node.
-
-   {% include note.html content="Running this command will also remove the AD group from sudoers list."%}
-
-For more about setting up Active Directory access, see [Enable Active Directory based access]({{ site.baseurl }}/admin/setup/active-directory-based-access.html).
-
 ### ssl
 
 ```
@@ -888,6 +862,33 @@ This subcommand supports the following actions:
 * `tscli ssl status` Shows whether SSL authentication is enabled or disabled.
 * `tscli ssl tls-status [-h]`  Prints the status of TLS support.
 
+### sssd
+
+```
+tscli sssd {enable, disable, set-sudo-group, clear-sudo-group} ...
+```
+
+This subcommand uses system security services daemon (SSSD), and has the following actions:
+
+* `tscli sssd enable --user` *`USER`* `--domain` *`DOMAIN`*
+
+   Enables system Active Directory (AD) user access on a single node. You will be
+   prompted for password credentials. The user must have permission to join a
+   computer or VM to the domain.
+
+* `tscli sssd disable`
+
+  Disables system AD based access on a local node. Running this command will also remove the AD group from sudoers list.
+
+* `tscli sssd set-sudo-group` *`ACTIVE_DIRECTORY_GROUP_NAME`*
+
+   Allows `sudo` permissions for AD group.
+
+* `tscli sssd clear-sudo-group` *`ACTIVE_DIRECTORY_GROUP_NAME`*
+
+   Clears any set AD sudo group.
+
+For more about setting up Active Directory access, see [Enable Active Directory based access]({{ site.baseurl }}/admin/setup/active-directory-based-access.html).
 
 ### storage
 


### PR DESCRIPTION
### Review comments on first draft
* added new subcommand `clear-sudo-group` to `tscli` reference and Admin Guide
* put `sssd` in correct alpha order in reference
* verified notes about impact of `tscli sssd disable` on AD `sudo` group` (Kevin's comments but we already had it in there

### Related PRs

#490, #491, #492 

Signed-off-by: Victoria Bialas <vicky@thoughtspot.com>