### PR TITLE
review comments on app embedding docs bug

### DIFF
--- a/_app-integrate/embedding-viz/about-full-embed.md
+++ b/_app-integrate/embedding-viz/about-full-embed.md
@@ -29,7 +29,7 @@ section.
 ## A single page with the full application embedded
 
 The following sample <a href="{{"/downloads/embed.html" | prepend: site.baseurl }}"
-target="_blank"><code>embed.html</code></a> demonstrates how you might full
+target="_blank" class="_"><code>embed.html</code></a> demonstrates how you might full
 embed app the application.
 
 ```
@@ -106,5 +106,3 @@ Here are some additional notes about the full embed feature:
 -   Call `thoughtspot.<customerURL>.com/#/answer` and use that to access the search functionality.
 -   Call `thoughtspot.<customerURL>.com/#/pinboards` and use that to access saved pinboards.
 -   Use SAML for authentication against ThoughtSpot within the iFrame.
-
-Finally, to hide the top navigation or the expandable left panel that shows data sources and fields within the current data source, contact ThoughtSpot Support.


### PR DESCRIPTION
- Corrected docs based on this feedback from Jasmeet, Gaurav, and Shiwani on Slack (only to remove last sentence, _not_ a full update to the doc for usability)

_Hi, Gaurav Rajguru pointed out an issue with the docs regarding app customization. The feature is not supported._ 

_The last statement `Finally, to hide the top navigation or the expandable left panel that shows data sources and fields within the current data source, contact ThoughtSpot Support.` is invalid and we should remove it. The rest of the doc is correct but not very understandable._

Will cherry pick into `5.0` as well.


Signed-off-by: Victoria Bialas <vicky.bialas@gmail.com>