### PR TITLE
SCAL-35237: i18n docs updates

### DIFF
--- a/_includes/content/keywords-translate/fr-CA/keywords-comparative-fr-CA.md
+++ b/_includes/content/keywords-translate/fr-CA/keywords-comparative-fr-CA.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (Canada) Keywords</th>
+    <th class="tg-31q5">Français Keywords</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-CA/keywords-date-fr-CA.md
+++ b/_includes/content/keywords-translate/fr-CA/keywords-date-fr-CA.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-j0ga">English Keywords</th>
-    <th class="tg-j0ga">Français (Canada) Keywords</th>
+    <th class="tg-j0ga">Français Keywords</th>
     <th class="tg-j0ga">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-CA/keywords-general-fr-CA.md
+++ b/_includes/content/keywords-translate/fr-CA/keywords-general-fr-CA.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (Canada) Keywords</th>
+    <th class="tg-31q5">Français Keywords</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-CA/keywords-location-fr-CA.md
+++ b/_includes/content/keywords-translate/fr-CA/keywords-location-fr-CA.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (Canada) Keywords</th>
+    <th class="tg-31q5">Français Keywords</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-CA/keywords-number-fr-CA.md
+++ b/_includes/content/keywords-translate/fr-CA/keywords-number-fr-CA.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (Canada) Keywords</th>
+    <th class="tg-31q5">Français Keywords</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-CA/keywords-period-fr-CA.md
+++ b/_includes/content/keywords-translate/fr-CA/keywords-period-fr-CA.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (Canada) Keywords</th>
+    <th class="tg-31q5">Français Keywords</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-CA/keywords-text-fr-CA.md
+++ b/_includes/content/keywords-translate/fr-CA/keywords-text-fr-CA.md
@@ -8,7 +8,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (Canada) Keywords</th>
+    <th class="tg-31q5">Français Keywords</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-CA/keywords-time-fr-CA.md
+++ b/_includes/content/keywords-translate/fr-CA/keywords-time-fr-CA.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-j0ga">English Keywords</th>
-    <th class="tg-j0ga">Français (Canada) Keywords</th>
+    <th class="tg-j0ga">Français Keywords</th>
     <th class="tg-j0ga">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-FR/keywords-comparative-fr-FR.md
+++ b/_includes/content/keywords-translate/fr-FR/keywords-comparative-fr-FR.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (France)</th>
+    <th class="tg-31q5">Français</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-FR/keywords-date-fr-FR.md
+++ b/_includes/content/keywords-translate/fr-FR/keywords-date-fr-FR.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-j0ga">English Keywords</th>
-    <th class="tg-j0ga">Français (France)</th>
+    <th class="tg-j0ga">Français</th>
     <th class="tg-j0ga">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-FR/keywords-general-fr-FR.md
+++ b/_includes/content/keywords-translate/fr-FR/keywords-general-fr-FR.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (France)</th>
+    <th class="tg-31q5">Français</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-FR/keywords-location-fr-FR.md
+++ b/_includes/content/keywords-translate/fr-FR/keywords-location-fr-FR.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (France)</th>
+    <th class="tg-31q5">Français</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-FR/keywords-number-fr-FR.md
+++ b/_includes/content/keywords-translate/fr-FR/keywords-number-fr-FR.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (France)</th>
+    <th class="tg-31q5">Français</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-FR/keywords-period-fr-FR.md
+++ b/_includes/content/keywords-translate/fr-FR/keywords-period-fr-FR.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (France)</th>
+    <th class="tg-31q5">Français</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-FR/keywords-text-fr-FR.md
+++ b/_includes/content/keywords-translate/fr-FR/keywords-text-fr-FR.md
@@ -8,7 +8,7 @@
 <table class="tg">
   <tr>
     <th class="tg-31q5">English Keywords</th>
-    <th class="tg-31q5">Français (France)</th>
+    <th class="tg-31q5">Français</th>
     <th class="tg-31q5">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/keywords-translate/fr-FR/keywords-time-fr-FR.md
+++ b/_includes/content/keywords-translate/fr-FR/keywords-time-fr-FR.md
@@ -9,7 +9,7 @@
 <table class="tg">
   <tr>
     <th class="tg-j0ga">English Keywords</th>
-    <th class="tg-j0ga">Français (France)</th>
+    <th class="tg-j0ga">Français</th>
     <th class="tg-j0ga">Examples</th>
   </tr>
   <tr>

--- a/_includes/content/set_locale.md
+++ b/_includes/content/set_locale.md
@@ -1,4 +1,4 @@
-The language the ThoughtSpot UX displays is based off of the locale in a user's
+The language the ThoughtSpot UI displays is based off of the locale in a user's
 profile. The locale preferences control the language and data formats (date and
 number formats) by geographic locations. In addition to American English (*en-US*),
 ThoughtSpot supports:

--- a/_reference/keywords.md
+++ b/_reference/keywords.md
@@ -12,16 +12,11 @@ examples from within the help center.
 
 ### Keywords in Other Languages
 
-The language the ThoughtSpot UX displays is based on how you set
-[locale preferences in your user profile]({{ site.baseurl }}/end-user/introduction/about-user.html). The locale preferences control the language and data formats (date and number
-formats) by geographic locations.
-
 Currently, we offer the following keyword translations.
 
 <!-- | [日本語]({{ site.baseurl }}/reference/keywords-ja-JP.html) | [Deutsche]({{ site.baseurl }}/reference/keywords-de-DE.html) |
 
  | **[日本語]({{ site.baseurl }}/reference/keywords-ja-JP.html)** |   | **[中文 (简体)]({{ site.baseurl }}/reference/keywords-translate/keywords-zh-CN.html)** | **[Deutsche]({{ site.baseurl }}/reference/keywords-de-DE.html)** | **[Español (latín)]({{ site.baseurl }}/reference/keywords-es-US.html)** | **[Français (Canada)]({{ site.baseurl }}/reference/keywords-fr-CA.html)** | **[Français (France)]({{ site.baseurl }}/reference/keywords-fr-FR.html)** | **[Português (Brasil)]({{ site.baseurl }}/reference/keywords-pt-BR.html)** | -->
-
 
 <table style="width: 70%; border-spacing: 2px;">
   <tr>
@@ -45,9 +40,10 @@ Currently, we offer the following keyword translations.
     <td><a href="{{ site.baseurl }}/reference/keywords-nb-NO.html">Norsk</a></td>
     <td><a href="{{ site.baseurl }}/reference/keywords-nl-NL.html">Nederland</a></td>
   </tr>
-
-
 </table>
+
+Also, see the topic on how to set [locale preferences in your user profile]({{ site.baseurl }}/end-user/introduction/about-user.html) to control language, date, and number formats on the ThoughtSpot UI.
+
 
 ## General
 

--- a/_reference/keywords.md
+++ b/_reference/keywords.md
@@ -12,6 +12,10 @@ examples from within the help center.
 
 ### Keywords in Other Languages
 
+The language the ThoughtSpot UX displays is based on how you set
+[locale preferences in your user profile]({{ site.baseurl }}/end-user/introduction/about-user.html). The locale preferences control the language and data formats (date and number
+formats) by geographic locations.
+
 Currently, we offer the following keyword translations.
 
 <!-- | [日本語]({{ site.baseurl }}/reference/keywords-ja-JP.html) | [Deutsche]({{ site.baseurl }}/reference/keywords-de-DE.html) |


### PR DESCRIPTION
- linked keywords reference to locale preferences
- removed parenthetical location on table titles of French Canadian and French France keywords pages to be consistent with other similar pages

Related PRs #545 (this PR includes those changes and more)