### PR TITLE
Removed path per guidance from SCAL-34153

### DIFF
--- a/_data-integrate/clients/use-jdbc-driver.md
+++ b/_data-integrate/clients/use-jdbc-driver.md
@@ -21,7 +21,7 @@ activities.
 | Information | Description |
 |-------------|-------------|
 |Driver name | `com.simba.client.core.jdbc4.SCJDBC4Driver` |
-|Server IP address | The ThoughtSpot appliance URL or IP address. The IP address can be found by going to `http://<server-ip\>/internal/status/service?name=simba_server`|
+|Server IP address | The ThoughtSpot appliance URL or IP address.|
 |Simba port | The simba port, which is `12345` by default.|
 |Database name | This is not the machine login username. The ThoughtSpot Database name to connect to.|
 |username | The name of a ThoughtSpot user with administrator permissions.|


### PR DESCRIPTION
### What's changed:

- Removed: "The IP address can be found by going to http://<server-ip\>:2201/status/service?name=simba_server" from the Server IP address description on: https://docs.thoughtspot.com/5.1/data-integrate/clients/use-jdbc-driver.html per guidance from [SCAL-34153](https://thoughtspot.atlassian.net/browse/SCAL-34153)

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>