### PR TITLE
Updated references to ellipses menu to remove '(3 dots)'

### DIFF
--- a/_admin/loading/schema-viewer.md
+++ b/_admin/loading/schema-viewer.md
@@ -17,7 +17,7 @@ You need **Admin** privileges to use the **Schema Viewer**.
 ## Bringing up the Schema Viewer
 
 You can bring up the Schema Viewer from the **Data** screen. Click the ellipses icon
-(3 dots) ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline},
+ ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline},
 and select **View Schema**.
 
  ![]({{ site.baseurl }}/images/access_schema_viewer.png "Access the Schema

--- a/_admin/loading/upload-sql-script.md
+++ b/_admin/loading/upload-sql-script.md
@@ -16,7 +16,7 @@ You can run a SQL script to create your database schema through the browser, wit
 
 2. Click **Data**, on the top navigation bar.
 
-3. Click the ellipses icon (3 dots) ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Upload schema**.
+3. Click the ellipses icon ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Upload schema**.
 
      ![]({{ site.baseurl }}/images/import_schema.png "Upload schema")
 

--- a/_admin/worksheets/about-worksheets.md
+++ b/_admin/worksheets/about-worksheets.md
@@ -54,7 +54,7 @@ To create a new worksheet:
 
 1. Click **Data**, on the top navigation bar.
 
-2. Click the the ellipses icon (3 dots) ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Create worksheet**.
+2. Click the the ellipses icon ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Create worksheet**.
 
     ![]({{ site.baseurl }}/images/worksheet_create_icon.png)
 
@@ -105,7 +105,7 @@ To add the sources to the worksheet:
 
      ![]({{ site.baseurl }}/images/worksheet_add_col_prefix.png "Add a prefix to column names")
 
-13. Click the the ellipses icon (3 dots) ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Save**.
+13. Click the the ellipses icon ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Save**.
 
     ![]({{ site.baseurl }}/images/action_save_worksheet.png "Save a worksheet")
 

--- a/_admin/worksheets/change-inclusion-rule.md
+++ b/_admin/worksheets/change-inclusion-rule.md
@@ -38,12 +38,12 @@ To configure these values for a worksheet:
 
 5. Scroll to the bottom of the page.
 
-5. Configure the worksheet join rule and RLS setting as needed.
+6. Configure the worksheet join rule and RLS setting as needed.
 
      ![]({{ site.baseurl }}/images/worksheet_choose_sources_from_2.5.png "The worksheet join rule and RLS setting")
 
-6. Click **CLOSE**.
+7. Click **CLOSE**.
 
-7. Click the the ellipses icon (3 dots) ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Save**.
+8. Click the the ellipses icon ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Save**.
 
     ![]({{ site.baseurl }}/images/action_save_worksheet.png "Save a worksheet")

--- a/_admin/worksheets/edit-worksheet.md
+++ b/_admin/worksheets/edit-worksheet.md
@@ -20,7 +20,7 @@ To edit a worksheet:
 
 4. Make your changes to the worksheet.
 
-5.  Click the the ellipses icon (3 dots) ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Save**.
+5.  Click the the ellipses icon ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Save**.
 
     ![]({{ site.baseurl }}/images/action_save_worksheet.png "Save a worksheet")
 

--- a/_app-integrate/data-api/push-data-to-external-app.md
+++ b/_app-integrate/data-api/push-data-to-external-app.md
@@ -36,7 +36,7 @@ Use this procedure to create an Custom Action in ThoughtSpot:
 
    ![]({{ site.baseurl }}/images/create_custom_action.png)
 
-5. Now when a user is viewing a search result, they'll have the option to use the Custom Action you created. To initiate the action, they'll click the ellipses icon (3 dots)
+5. Now when a user is viewing a search result, they'll have the option to use the Custom Action you created. To initiate the action, they'll click the ellipses icon 
 ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Your Action Name**. You'll notice a **Custom** tag next to your action name to indicate that this is something custom built, and not a ThoughtSpot action.
 
    ![]({{ site.baseurl }}/images/initiate_custom_action.png)

--- a/_app-integrate/data-api/use-data-api-read.md
+++ b/_app-integrate/data-api/use-data-api-read.md
@@ -17,7 +17,7 @@ Use this procedure to construct the URL you will use to call the REST API:
 2. Navigate to the pinboard from which you want to get data. If it doesn't exist yet, create it now.
 
 3. Find the ID number of the object you want to get the data from. If the object is:
-    -   A pinboard, click ellipses icon (3 dots) ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline} the and select **Copy Link**.
+    -   A pinboard, click ellipses icon ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline} the and select **Copy Link**.
 
         ![]({{ site.baseurl }}/images/copy_pinboard_link.png "The Actions menu")
 

--- a/_app-integrate/embedding-viz/embed-a-viz.md
+++ b/_app-integrate/embedding-viz/embed-a-viz.md
@@ -6,7 +6,7 @@ sidebar: mydoc_sidebar
 toc: true
 permalink: /:collection/:path.html
 ---
-The page explains, through an example, how to embed a visualization (table or
+This page explains, through an example, how to embed a visualization (table or
 chart) or pinboard from ThoughtSpot in your own static Web page, portal, or
 application.
 
@@ -28,7 +28,7 @@ before continuing.
 
 3. Copy the URL for the entire pinboard and for a single visualization.
 
-   If the object is a pinboard, click the ellipses icon (3 dots)
+   If the object is a pinboard, click the ellipses icon
    ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline} >
     **Copy Link**.
 
@@ -36,7 +36,7 @@ before continuing.
 
    The format for the link is:  `<protocol>:<host>:<port>/#/embed/viz/<pinboardID>`
 
-   For a vizualization in a pinboard, click the ellipses icon (3 dots)
+   For a vizualization in a pinboard, click the ellipses icon 
    ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline} >
     **Copy Link**.
 

--- a/_complex-search/about-filters.md
+++ b/_complex-search/about-filters.md
@@ -57,7 +57,7 @@ You can apply simple filters to your search, whether it shows a table or a
 chart. Your filters remain part of the search even when you change the
 visualization type.
 
-When adding a filter from the ellipses icon (3 dots)
+When adding a filter from the ellipses icon 
 ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline},
 in the column header or by clicking on a chart axis, numeric columns and
 text columns provide you with the ability to include or exclude values, and

--- a/_complex-search/create-aggregated-worksheet.md
+++ b/_complex-search/create-aggregated-worksheet.md
@@ -15,7 +15,7 @@ This procedure walks you through creating a view from a search. To create a view
 2. Make any changes to the visualization that you want in your saved view (change aggregation level, filters, etc.)
 
 3. Click the ellipses icon
-(3 dots) ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline},
+ ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline},
 and **Save as view**.
 
      ![]({{ site.baseurl }}/images/save_as_view.png "Save as a View")

--- a/_complex-search/do-query-on-query.md
+++ b/_complex-search/do-query-on-query.md
@@ -20,7 +20,7 @@ After creating a view and linking it to related data, you're ready to create you
 
 4. Once you have the expected answer, you can create a worksheet to make it easier for you and other people to use. To do this, click **Data**.
 
-5. Click the ellipses icon (3 dots)
+5. Click the ellipses icon 
 ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline},
 and select **Create worksheet**.
 

--- a/_end-user/r-scripts/create-r-scripts.md
+++ b/_end-user/r-scripts/create-r-scripts.md
@@ -123,7 +123,7 @@ You can click these icons in the R script dialog to get more options:
 ![more options menu icon]({{ site.baseurl }}/images/r-icon-i.png){: .inline}
 provides a basic reference guide for creating an R analysis in ThoughtSpot.
 
-* The ellipses icon (3 dots)
+* The ellipses icon 
 ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}
 provides a menu with options to save or load a previously saved R script, as well as
 share your R script with other users in the system.

--- a/_end-user/search/filter-from-column-headers.md
+++ b/_end-user/search/filter-from-column-headers.md
@@ -9,7 +9,7 @@ permalink: /:collection/:path.html
 To add a filter from column headers:
 
 1. While viewing your answer as a table, hover over the column header you
-want to filter, and click the ellipses icon (3 dots) 
+want to filter, and click the ellipses icon 
 ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}.
 
      ![]({{ site.baseurl }}/images/change_configuration_of_a_column.png "Change configuration of a column")

--- a/_includes/content/csv-load.md
+++ b/_includes/content/csv-load.md
@@ -4,7 +4,7 @@ Any user who belongs to a group that has the privilege **Has administration priv
 
 2. Click **Data**, on the top navigation bar.
 
-3. Click the the ellipses icon (3 dots)
+3. Click the ellipses icon
 ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline},
 in the upper right corner, and select **Upload Data**.
 

--- a/_includes/content/share-pinboard.md
+++ b/_includes/content/share-pinboard.md
@@ -3,7 +3,7 @@ When you share a pinboard what you are really sharing is a live link to the pinb
 To share a pinboard:
 
 1. Configure it to look as you'll want it to appear when shared.
-2. From within a pinboard, click the ellipses icon (3 dots)
+2. From within a pinboard, click the ellipses icon 
 ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline},
 and select **Share**.
 

--- a/_spotiq/overview.md
+++ b/_spotiq/overview.md
@@ -41,7 +41,7 @@ item and department.
 
 1. If you haven't already, sign in to the ThoughtSpot application and click the **Data** tab.
 
-2. Click the ellipses icon (3 dots) ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Upload data**.
+2. Click the ellipses icon ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline}, and select **Upload data**.
 
 3. Browse to the sample data file you downloaded or drag the file into the upload area.
 


### PR DESCRIPTION
What's new
- Changed 'the the' to 'the'
- Removed all instances of '(3 dots)' associated with ellipses menu