### PR TITLE
Rearranged information about CPU core and RAM

### DIFF
--- a/_appliance/vmware/vmware-setup.md
+++ b/_appliance/vmware/vmware-setup.md
@@ -13,7 +13,6 @@ Hypervisor (ESXi) 6.5 environment.  For each hardware node, you must:
 a virtual machine (VM)
 * Add hard disks to the VM
 
-
 ## Prerequisites
 
 This installation process assumes you have already acquired your host machines.
@@ -25,7 +24,9 @@ for a sandbox environment but is insufficient for a production environment.
    The VM template, by default, captures a 72-core configuration. If your
    physical host has more than 72 cores, you may want to edit VM to have (`n-2`)
    cores (for a physical host with n cores) to fully take advantage of computing
-   power of the physical host.
+   power of the physical host. Extra cores help performance.
+   
+   You should aim to allocate 490 GB or more RAM.
 
 2. Create datastores for all solid-state drive (SSD) and hard drive devices.
 
@@ -90,9 +91,6 @@ additional, larger capacity disks.
    ![]({{ site.baseurl }}/images/vmware-add-disk0.png "Select disk")
 
 2. Select **Add hard disk > New hard disk**.
-
-   You can give the VM up to 72 cores (or approximately 490 G RAM). The ESXi host
-   should keep a minimum of 2 cores.
 
    ![]({{ site.baseurl }}/images/vmware-adddisk1.png "New hard disk")
 


### PR DESCRIPTION
Rearranged information about CPU core and RAM - Instead of up-to 72 cores, the config is now minimum 72 cores - which seems logical. Please get PM to review this item before publishing.

For RAM, made sure to indicate in the right place that we need 490GB RAM or more. Initially this information was embedded in section related to hard disk provisioning.

Feel free to delete my github branch once you've reviewed/incorporated my changes. Thanks.