### PR TITLE
5 1 updates

### DIFF
--- a/_release/notes.md
+++ b/_release/notes.md
@@ -12,7 +12,7 @@ permalink: /:collection/:path.html
 ThoughtSpot version 5.1.1 is now available. These release notes include information about new features,
 fixed issues from the previous releases, and any known issues.
 
-<!-- * [5.1.2 Fixed Issues](#512-fixed)-->
+
 * [5.1.1 New Features](#511-new)
 * [5.1.1 Fixed Issues](#511-fixed)
 * [5.1 New Features](#51-new)
@@ -33,7 +33,7 @@ directly:
 If you are running a different version, you must do a multiple pass upgrade.
 First, upgrade to one of the above versions, and then to the 5.1.1 release.
 
-<!-- {: id="512-fixed"}
+{: id="512-fixed"}
 ## 5.1.2 Fixed Issues
 
 Search no longer stops working under certain conditions like fast typing, or copying and pasting of a search query.
@@ -46,7 +46,7 @@ When removing a node, the node calling command no longer results in unreachabili
 
 Permissions issues with `tsload` and `tql` are now fixed so the **thoughspot** user can load data.
 
-Database stability has been improved. -->
+Database stability has been improved.
 
 {: id="511-new"}
 ## 5.1.1 New Features and Functionality

--- a/_release/notes.md
+++ b/_release/notes.md
@@ -33,21 +33,6 @@ directly:
 If you are running a different version, you must do a multiple pass upgrade.
 First, upgrade to one of the above versions, and then to the 5.1.1 release.
 
-{: id="512-fixed"}
-## 5.1.2 Fixed Issues
-
-Search no longer stops working under certain conditions like fast typing, or copying and pasting of a search query.
-
-Selecting 'Copy and Edit' in an answer, pinboard visualization, insight, SpotIQ pinboard or view, no longer causes the user to be signed out.
-
-HDFS images for a cluster are now created prior to pushing the HDFS configuration. This ensures images are fresh during an upgrade.
-
-When removing a node, the node calling command no longer results in unreachability due to misconfigured firewall settings.
-
-Permissions issues with `tsload` and `tql` are now fixed so the **thoughspot** user can load data.
-
-Database stability has been improved.
-
 {: id="511-new"}
 ## 5.1.1 New Features and Functionality
 


### PR DESCRIPTION
### What's new:

- removing 5.1.2 release notes content, in order to republish 5.1 site to incorporate bug fixes and new content.