### PR TITLE
update to title of firewall ports page

### DIFF
--- a/_appliance/firewall-ports.md
+++ b/_appliance/firewall-ports.md
@@ -1,5 +1,5 @@
 ---
-title: [Network ports]
+title: [Network policies]
 keywords: network, ports
 tags: [networking]
 last_updated: tbd


### PR DESCRIPTION
### What's new:
- fixed title of Network ports page to match toc "Network policies"

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>