### PR TITLE
Commenting out 5.1.2 release notes so we can branch to 5.2

### DIFF
--- a/_appliance/firewall-ports.md
+++ b/_appliance/firewall-ports.md
@@ -1,5 +1,5 @@
 ---
-title: [Network ports]
+title: [Network policies]
 keywords: network, ports
 tags: [networking]
 last_updated: tbd

--- a/_appliance/vmware/vmware-intro.md
+++ b/_appliance/vmware/vmware-intro.md
@@ -40,6 +40,14 @@ _minimum specifications_ for an individual VMware ESXi host machine:
 * 72 Hyper-threaded Cores (Additional spare cores can also be added. Oversubscription is not supported).
 * Intel Xeon 2600 series operating at clock frequencies 2.1GHz (Faster is better).
 
+Locally attached storage provides the best performance.
+
+SAN can be used, but must comply with the following requirements:
+* 136 MBps minimum random read bandwidth
+* 240 random IOPS (~4s seek latency)
+
+NAS/NFS is not supported since its latency is so high that it tends to be unreliable.
+
 All virtualization hosts should have VMware vSphere Hypervisor (ESXi) 6.5 installed.
 
 ThoughtSpot provides a VMware template (OVF) together with a VMDK (Virtual

--- a/_includes/content/ports-network.md
+++ b/_includes/content/ports-network.md
@@ -87,6 +87,7 @@ If your organization does not allow you to open all ports, make sure you open th
 |6311|TCP|R service|bidirectional|All nodes|All nodes|Services|
 |8008|TCP|Video recorder|bidirectional|All nodes|All nodes|Services|
 |9090|TCP|Timely|bidirectional|All nodes|All nodes|Services|
+||ICMPv4|Used for health check of cluster nodes|bidirectional|All nodes|All nodes|Services|
 
 ### Required ports for inbound and outbound cluster access
 

--- a/_release/notes.md
+++ b/_release/notes.md
@@ -9,10 +9,10 @@ permalink: /:collection/:path.html
 
 ## What's in the Release Notes
 
-ThoughtSpot version 5.1.2 is now available. These release notes include information about new features,
+ThoughtSpot version 5.1.1<!-- 5.1.2 --> is now available. These release notes include information about new features,
 fixed issues from the previous releases, and any known issues.
 
-* [5.1.2 Fixed Issues](#512-fixed)
+<!-- * [5.1.2 Fixed Issues](#512-fixed) -->
 * [5.1.1 New Features](#511-new)
 * [5.1.1 Fixed Issues](#511-fixed)
 * [5.1 New Features](#51-new)
@@ -21,19 +21,19 @@ fixed issues from the previous releases, and any known issues.
 
 ## Supported Upgrade Paths
 
-If you are running one of the following versions, you can upgrade to the 5.1.2 release
+If you are running one of the following versions, you can upgrade to the 5.1.1 <!-- 5.1.2--> release
 directly:
 
-* 4.5.1.x to 5.1.2
-* 5.0.x to 5.1.2
-* 5.1.x to 5.1.2
+* 4.5.1.x to 5.1.1 <!-- 5.1.2 -->
+* 5.0.x to 5.1.1 <!-- 5.1.2 -->
+* 5.1.x to 5.1.1 <!-- 5.1.2 -->
 
 (This includes any hotfixes or customer patches on these branches.)
 
 If you are running a different version, you must do a multiple pass upgrade.
-First, upgrade to one of the above versions, and then to the 5.1.2 release.
+First, upgrade to one of the above versions, and then to the 5.1.1<!-- 5.1.2 --> release.
 
-{: id="512-fixed"}
+<!-- {: id="512-fixed"}
 ## 5.1.2 Fixed Issues
 
 Search no longer stops working under certain conditions like fast typing, or copying and pasting of a search query.
@@ -47,7 +47,7 @@ When removing a node, the node calling command no longer results in unreachabili
 Permissions issues with `tsload` and `tql` are now fixed so the **thoughspot** user can load data.
 
 Database stability has been improved.
-
+-->
 {: id="511-new"}
 ## 5.1.1 New Features and Functionality
 


### PR DESCRIPTION
What's new:
- Commenting out 5.1.2 release notes (so we can create branch for 5.2 docs)
- Updated to add new VMware configuration overview page to address SCAL-33004