### PR TITLE
Update to the ODBC command for DELETE FROM

### DIFF
--- a/_data-integrate/reference/odbc-commands.md
+++ b/_data-integrate/reference/odbc-commands.md
@@ -34,7 +34,7 @@ These SQL commands are supported for ODBC:
 
 * `DELETE FROM <table>`
 
-    Deletes `ALL` rows from the specified table. Does not support the `WHERE` clause.
+    Deletes `ALL` rows from the specified table. Use the `WHERE` clause to specify only certain rows to be deleted. Example: You could remove all data for sales before a certain date to free up space in ThoughtSpot.
 
     ```
     DELETE FROM country_dim;

--- a/_release/notes.md
+++ b/_release/notes.md
@@ -21,6 +21,7 @@ fixed issues from the previous releases, and any known issues.
 If you are running one of the following versions, you can upgrade to the 5.2 release
 directly:
 
+* 4.5.x to 5.2
 * 5.0.x to 5.2
 * 5.1.x to 5.2
 


### PR DESCRIPTION
### What's new:
- Updated the SQL DELETE FROM command for ODBC to include support for WHERE clause (SCAL-39843)
- Updated release notes to include the supported upgrade paths for 5.2

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>