### PR TITLE
updated ODBC sql command for DELETE FROM to include WHERE clause

### DIFF
--- a/_data-integrate/reference/odbc-commands.md
+++ b/_data-integrate/reference/odbc-commands.md
@@ -34,7 +34,7 @@ These SQL commands are supported for ODBC:
 
 * `DELETE FROM <table>`
 
-    Deletes `ALL` rows from the specified table. Does not support the `WHERE` clause.
+    Deletes `ALL` rows from the specified table. Use the `WHERE` clause to specify only certain rows to be deleted. Example: You could remove all data for sales before a certain date to free up space in ThoughtSpot.
 
     ```
     DELETE FROM country_dim;


### PR DESCRIPTION
### What's changed:
- Added WHERE clause to the ODBC SQL command for DELETE FROM (SCAL-39843)

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>