### PR TITLE
Add third party install draft and tscli ansible

### DIFF
--- a/_admin/data-security/about-secure-monitor-sw.md
+++ b/_admin/data-security/about-secure-monitor-sw.md
@@ -1,0 +1,64 @@
+---
+title: [About third party security and monitoring software]
+keywords: qualys,splunk,security,third party,installation,SNMP
+tags: [logs,security]
+summary: "You can install third party software for security, governance, and monitoring of ThoughtSpot."
+sidebar: mydoc_sidebar
+permalink: /:collection/:path.html
+---
+In addition to the ThoughtSpot monitoring and security features, some companies require specific additional third party software to comply with their internal IT policies. This allows them to support all of their systems with a common set of security and management tools.
+
+For example, you may wish to accomplish some security and monitoring tasks with your own third party software. These tasks include things like pushing alerts, events, forensics, audit trails, insights, etc. from ThoughtSpot to your own local monitoring systems.
+
+## Supported third party software
+
+ThoughtSpot supports installation of the following third party software on the ThoughtSpot instance:
+
+- Qualys
+  Qualys is a widely used technical vulnerabilities and security compliance scanning tool. For more information about Qualys, see the [Qualys documentation](http://www.qualys.com/documentation/).
+
+- SNMP (Simple Network Management Protocol)
+  SNMP is an industry standard protocol used for monitoring network traffic and alert events.
+
+- Splunk
+  You can install Splunk rsyslog and use it to forward ThoughtSpot logs to Splunk. For more information about Splunk, see the [Splunk documentation](http://docs.splunk.com/).
+
+## What is not supported
+
+When installing and configuring third party software on a ThoughtSpot cluster, follow the following guidelines to avoid interfering with cluster operations:
+
+- Avoid making any direct changes to any files outside of the /home directory.
+- Do not remove existing SSH keys or authorized keys from /home/admin/.ssh
+- Excessive resource usage, e.g. CPU, disk, memory, processes, etc.
+- Killing any system or ThoughtSpot services, or causing node reboots.
+
+Do not change any system wide configuration which may affect ThoughtSpot, such as:
+- Network, e.g. IP addresses, DNS resolution
+- Storage, e.g. removing existing mount points, removing drives
+- Security, e.g. selinux
+
+## Qualys
+
+Qualys is supported for scanning of ThoughtSpot clusters for security vulnerabilities.
+
+## SNMP Traps
+
+ThoughtSpot has a built-in alerting service that can also be used to send SNMP traps. Many third party monitoring systems share the common standard of using SNMP traps, and you can take advantage of those capabilities with ThoughtSpot.
+
+ThoughtSpot supports SNMP for read only. So for example, you can read the IP address of the cluster, but not change it using SNMP.
+
+See the [Alert code reference]({{ site.baseurl}}/reference/alerts-reference.html#) for details.
+
+## Splunk rsyslog
+
+ThoughtSpot monitoring and alerting logs are written to standard locations in the file system. This allows you to use rsyslog to collect them and send them to Splunk.
+
+Here are some links to help you learn where various logs are written in ThoughtSpot:
+
+- [Monitoring logs]({{ site.baseurl}}/admin/system-monitor/introduction.html#)
+- [Audit logs]({{ site.baseurl}}/admin/data-security/audit-logs.html#)
+- [Alert code reference]({{ site.baseurl}}/reference/alerts-reference.html#)
+
+## Related Topics
+
+- [Installing third party security and monitoring software]({{ site.baseurl}}/admin/data-security/install-secure-monitor-sw.html#)

--- a/_admin/data-security/audit-logs.md
+++ b/_admin/data-security/audit-logs.md
@@ -74,3 +74,7 @@ Security policies are the principles and processes ThoughtSpot uses in developme
 The ThoughtSpot Engineering and ThoughtSpot Support teams are notified of Common Vulnerabilities and Exposures (CVEs), so they can patch OS packages proactively as well. You can view installed packages along with their version numbers at any time, in order to see if you require an update to ThoughtSpot.
 
 Whenever a CVE is identified, and an OS package needs to be updated, the next patch release will include the patch or update. You can view installed Linux packages at any time, along with the version numbers of the installed packages.
+
+## Third party security software for security, governance, and monitoring of ThoughtSpot
+
+You can install supported [third party security and monitoring software]({{ site.baseurl}}/admin/data-security/about-secure-monitor-sw.html#) on a ThoughtSpot cluster.

--- a/_admin/data-security/install-secure-monitor-sw.md
+++ b/_admin/data-security/install-secure-monitor-sw.md
@@ -1,0 +1,46 @@
+---
+title: [Installing third party security and monitoring software]
+keywords: qualys,splunk,security,third party,installation,SNMP
+tags: [logs,security]
+summary: "You can install third party software for security, governance, and monitoring of ThoughtSpot."
+sidebar: mydoc_sidebar
+permalink: /:collection/:path.html
+---
+This procedure shows how to install supported [third party security and monitoring software]({{ site.baseurl}}/admin/data-security/about-secure-monitor-sw.html#) on a ThoughtSpot cluster:
+
+## To install third party software
+
+1. Log in to the Linux shell using SSH.
+
+2. Issue the `tscli ansible checkout` command, specifying a temporary directory, for example:
+
+    ```
+    $ tscli ansible checkout
+    Checking out playbooks successfully in /tmp/111895937.
+    ```
+3. Switch to the temporary directory that was created.
+
+    ```
+    $ cd /tmp/111895937
+    ```
+
+4. In the temporary directory, save or edit the playbooks and modules.  
+   If you want to create a global ordering between playbooks, name them in alphabetical order, e.g. 10.first.yml, 20.second.yml, etc. You can also specify the order line by line in order.txt within the same directory.
+
+5. Commit your changes. This command will validate the playbook first, and then apply it.
+
+   Use the --local flag if you want to commit the change only to local storage on the local node. Otherwise, push it will go to centralized storage, and your changes will apply to all nodes in the cluster.
+
+   - To apply your changes globally to all nodes in the cluster, issue the command:
+
+   ```
+   $ tscli ansible commit
+   ```
+
+   - To apply your changes on the local node only, issue the command:
+
+   ```
+   $ tscli ansible commit --local
+   ```
+
+   This commits your changes. If there is a problem with the configuration. you will see an error message in standard output.

--- a/_admin/system-monitor/introduction.md
+++ b/_admin/system-monitor/introduction.md
@@ -46,11 +46,9 @@ each subsystem. The individual log directories are the following:
 - `/export/logs/hadoop`
 - `/export/logs/zookeeper`
 
-You can also view [additional topics that also touch on log files]({{ site.baseurl
-}}/tags/tag_logs.html) throughout the documentation.
+You can also view [additional topics that also touch on [log files]({{site.baseurl}}/tags/tag_logs.html) throughout the documentation.
 
 ## System monitoring notifications
 
 You can configure ThoughtSpot to send emails to addresses you specify with
-monitoring reports and a cluster heartbeat. Follow these steps to [Set up
-monitoring]({{ site.baseurl }}/admin/setup/set-up-monitoring.html#).
+monitoring reports and a cluster heartbeat. Follow these steps to [Set up monitoring]({{ site.baseurl }}/admin/setup/set-up-monitoring.html#).

--- a/_app-integrate/introduction/introduction.md
+++ b/_app-integrate/introduction/introduction.md
@@ -17,7 +17,7 @@ Here are the top level topics on application integration:
 * [Using the JavaScript API]({{ site.baseurl }}/app-integrate/JSAPI/about-JS-API.html)
 * [SAML]({{ site.baseurl }}/app-integrate/SAML/about-SAML-integrations.html)
 * [REST API]({{ site.baseurl }}/app-integrate/data-api/about-data-api.html)
-* [Emdbed ThoughtSpot]({{ site.baseurl }}/app-integrate/embedding-viz/about-embedding-viz.html)
+* [Embed ThoughtSpot]({{ site.baseurl }}/app-integrate/embedding-viz/about-embedding-viz.html)
 * [Runtime Filters]({{ site.baseurl }}/app-integrate/runtime-filters/about-runtime-filters.html)
 * [Style Customization]({{ site.baseurl }}/app-integrate/custom-branding/perform-style-customization.html)
 * [API Reference]({{ site.baseurl }}/app-integrate/reference/public-api-reference.html)

--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -24,7 +24,7 @@ The `tscli` command has the following syntax:
 tscli [-h] [--helpfull] [--verbose] [--noautoconfig]
            [--autoconfig] [--yes] [--cluster <cluster>]
            [--zoo <zookeeper>] [--username username] [--identity_file identity_file]
-           {access,alert,backup,backup-policy,callhome,cassandra,cluster,command,dr-mirror,etl,event,feature,fileserver,firewall,hdfs,ipsec,ldap,logs,map-tiles,monitoring,nas,node,patch,rpackage,saml,scheduled-pinboards,smtp,snapshot,snapshot-policy,spot,sssd,ssl,storage,support,tokenauthentication}
+           {access,alert,ansible, backup,backup-policy,callhome,cassandra,cluster,command,dr-mirror,etl,event,feature,fileserver,firewall,hdfs,ipsec,ldap,logs,map-tiles,monitoring,nas,node,patch,rpackage,saml,scheduled-pinboards,smtp,snapshot,snapshot-policy,spot,sssd,ssl,storage,support,tokenauthentication}
 ```
 
 The `tscli` command has several subcommands such as `alert`, `backup`, and so forth. You issue a subcommand using the following format:
@@ -81,6 +81,18 @@ Use this subcommand to do the following:
 
    Unsilences the alert with *`alert_name`*. For example, `DISK_ERROR`.
 
+### ansible
+
+   ```
+   tscli ansible [-h] {checkout,commit} [--local] ...
+   ```
+
+   Use this subcommand to install and configure third party software on the ThoughtSpot cluster.
+
+   For details, see:
+
+   - [About third party security and monitoring software]({{ site.baseurl}}/admin/data-security/about-secure-monitor-sw.html#)
+   - [Installing third party security and monitoring software]({{ site.baseurl}}/admin/data-security/install-secure-monitor-sw.html#)
 
 ### backup
 


### PR DESCRIPTION
Signed-off-by: Alicia Avrach <alicia@thoughtspot.com>

Add draft doc for installation of third party agents for monitoring and security. Also added tscli ansible to tscli reference. Vishal Sawanker to review.