### PR TITLE
time syntax fix

### DIFF
--- a/_admin/troubleshooting/get-logs.md
+++ b/_admin/troubleshooting/get-logs.md
@@ -92,7 +92,7 @@ $ tscli logs collect --include system,orion --since 2h --out /tmp/debug.tar.gz
 This command collects logs from a specific time window:
 
 ```
-$ tscli logs collect --include system,orion --from 20150520-12:00:00 --to 20150522-12:30:00
+$ tscli logs collect --include system,orion --from 20150520-12:00 --to 20150522-12:30
 ```
 
 Advanced usage alert! You can also use `--include` and `--exclude` to specify filesystem paths as a glob pattern. This works like the Linux find(1) command. Pass all the entries in `--include` starting with `/` to find(1), and all entries in `--exclude` which are not selectors to find(1) using the `-not -path` flag.

--- a/_appliance/hardware/inthebox.md
+++ b/_appliance/hardware/inthebox.md
@@ -38,7 +38,7 @@ When your ThoughtSpot appliance arrives, the following items will be included:
 * Data center with proper cooling
 * 2U of rack space per appliance (post depth 26.5" - 36.4")
 * AC power
-  **Attention:** Refer to [Ivy Bridge and Haswell hardware details](inthebox.html#hardware-provided-by-thoughtspot) for power input requirements.
+  **Attention:** Refer to [Ivy Bridge and Haswell hardware details]({{ site.baseurl }}/appliance/hardware/hardware-and-deployment.html) for power input requirements.
 * 10GbE infrastructure (switch) - 1x port required / node
 * 100MbE infrastructure (switch) - 1x port required /node
 * Network cable Cat 5e/6 (node management)<sup>1</sup>


### PR DESCRIPTION
Fix time syntax error in 5.2 from SCAL-39991
Signed-off-by: Madhup Raj <madhup.raj@nb647.thoughtspot.int>