### PR TITLE
removed link to SpotIQ tutorial from docs index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@ sidebar: mydoc_sidebar
       <p class="iconTitle">VIDEOS AND TUTORIALS</p>
       <img class="indexImg" src="{{ "/images/start-home.png" | prepend: site.baseurl  }}" alt="" height="150  ">
         <p class="bookLink"><a href="{{ "/release/videos-list.html "| prepend: site.baseurl }}">Videos</a></p>
-        <p class="bookLink"><a href="{{ "/spotiq/overview.html "| prepend: site.baseurl }}">SpotIQ tutorial</a></p>
         <p class="bookLink"><a href="{{ "/end-user/introduction/about-navigating-thoughtspot.html "| prepend: site.baseurl }}">Getting started</a></p>
     </div>
     <div class="col-sm-3" style="background-color: #F8F9F8; padding: 15px; border: 3px solid white; height: 400px;>


### PR DESCRIPTION
### What's changed:
- Removed link to SpotIQ tutorial from docs index page.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>