### PR TITLE
updated topnav to have 5.2 as latest

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -14,7 +14,9 @@ topnav_dropdowns:
   sections:
     - title: Version
       sectionitems:
-        - title: latest (5.1)
+        - title: latest (5.2)
+          url: /5.2/index.html
+        - title: 5.1
           url: /5.1/index.html
         - title: 5.0
           url: /5.0/index.html


### PR DESCRIPTION
### What's changed:
- Updated topnav to have 5.2 as latest.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>