### PR TITLE
fixed broken link in 5.2 release notes

### DIFF
--- a/_release/notes.md
+++ b/_release/notes.md
@@ -73,7 +73,7 @@ For details, refer to: [Allow users to sign up]({{ site.baseurl }}/admin/users-g
 ### Improved Japanese date keywords
 
 Japanese-language users now have a more natural way of expressing date phrases in their queries.
-For details, refer to: [Japanese (日本語) date keyword reference]({{ site.baseurl }}/reference/keywords-ja-jp#date).
+For details, refer to: [Japanese (日本語) date keyword reference]({{ site.baseurl }}/reference/keywords-ja-JP.html#date).
 
 {: id="52-fixed"}
 ## 5.2 Fixed Issues


### PR DESCRIPTION
### What's New:
- Fixed broken link to Japanese date keywords page.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>