### PR TITLE
fixed link again

### DIFF
--- a/_release/notes.md
+++ b/_release/notes.md
@@ -73,7 +73,7 @@ For details, refer to: [Allow users to sign up]({{ site.baseurl }}/admin/users-g
 ### Improved Japanese date keywords
 
 Japanese-language users now have a more natural way of expressing date phrases in their queries.
-For details, refer to: [Japanese (日本語) date keyword reference]({{ site.baseurl }}/reference/keywords-ja-JP.html#date).
+For details, refer to: [Japanese (日本語) date keyword reference]({{ site.baseurl }}/reference/keywords-ja-JP.html).
 
 {: id="52-fixed"}
 ## 5.2 Fixed Issues


### PR DESCRIPTION
### What's changed:
- Fixed link to Japanese keywords (since linking to the URL+anchor tag Japanese Date keywords does not work after publishing, so am now linking to Japanese keywords page. user will have to scroll down to Date section)