### PR TITLE
removed outdate content from cloud services

### DIFF
--- a/_appliance/aws/configuration-options.md
+++ b/_appliance/aws/configuration-options.md
@@ -102,25 +102,6 @@ details on how to configure your placement groups.
     </tr>
   </table>
 
-## ThoughtSpot software license sizes
-
-ThoughtSpot only sells software licenses in multiples of 250 GB of data. So you
-can start with 250 GB, and add increments of 250 GB each time your data capacity
-needs increase. You can also choose to start off with more than 250 GB of data,
-as long as you know the best fit configuration for your data volume.
-
-## Lego blocks
-
-If you aren't sure what kind of configuration you need, it might help to think
-of the hardware configurations in terms of simple Lego blocks. The r4.16xlarge
-size can be seen as a 250 GB block.
-
-{% include note.html content="ThoughtSpot does not support sizes other than r4.16xlarge." %}
-
-Since the minimum data volume offered is 250 GB, you would need one r4.16xlarge
-block to match the data capacity. This scales linearly. So, 500 GB would require
-two r4.16xlarge blocks.
-
 ## Regions, availability zones, and placement groups
 
 AWS instances are configured to a location with regard to where the computing

--- a/_appliance/azure/configuration-options.md
+++ b/_appliance/azure/configuration-options.md
@@ -90,14 +90,3 @@ details on how to configure your scope and permissions.
        </td>
     </tr>
   </table>
-
-## Data capacity per node
-
-ThoughtSpot sizes nodes in multiples of 200 GB of data in Azure. This size
-refers to the amount of data in the CSV files you will be loading into
-ThoughtSpot. The 200GB number takes into account all replication of data done
-automatically by ThoughtSpot to provide redundancy and fast performance.
-
-You can start with 200 GB, and add increments of 200 GB each time your data
-capacity needs increase. You can also choose to start off with more than 200 GB
-of data, as long as you know the best fit configuration for your data volume.

--- a/_appliance/gcp/configuration-options.md
+++ b/_appliance/gcp/configuration-options.md
@@ -103,16 +103,3 @@ GCP provides several storage types and media options. ThoughtSpot requires [atta
 
 ThoughtSpot uses only persistent storage options. Instance storage (also known
 as "local storage") is not used for ThoughtSpot deployments on GCP.
-
-## Data capacity per node
-
-Each [GCP n1-highmem-64 machine](https://cloud.google.com/compute/docs/machine-types#highmem)
-has 416 GB of memory and can accommodate ~200 GB of ThoughtSpot dedicated data.
-This size refers to the amount of data in the CSV files you will be loading into
-ThoughtSpot. The 200 GB number takes into account all replication of data done
-automatically by ThoughtSpot to provide redundancy and fast performance.
-
-You can start with the minimum platform described here, and add capacity by
-adding nodes and disks as needed. You can also choose to start off with more
-data capacity, as long as you know the best fit configuration for your data
-volume.


### PR DESCRIPTION
### What's changed:
- Removed outdated licensing and data capacity per node info from AWS, Azure and GCP

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>