### PR TITLE
Automated footer copyright date for 5.2 site.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
    <div class="row">
       <div class="col-lg-12 footer">
         Generated: {{ site.time | date: "%b %-d, %Y"  }} <br />
-         &copy;{{ site.time | date: " 2015, 2019"  }} {{site.company_name}}.  All rights reserved. <br />
+         &copy;{{ site.time | date: " 2015, %Y"  }} {{site.company_name}}.  All rights reserved. <br />
          <!-- {% if page.last_updated %}<span>Page last updated:</span> {{page.last_updated}}<br/>{% endif %}  -->
          <p><img style="width:100px;" src="{{ "images/company_logo.png" | absolute_url }}" alt="Company logo"/></p>
       </div>


### PR DESCRIPTION
### What's changed:
- Automated footer copyright date so current year always appears.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>