### PR TITLE
copyright date automation docs page

### DIFF
--- a/_admin/misc/copyright.md
+++ b/_admin/misc/copyright.md
@@ -7,7 +7,7 @@ permalink: /:collection/:path.html
 ---
 Copyright for ThoughtSpot publications.
 
-© 2015, 2019 ThoughtSpot, Inc. All rights reserved.
+&copy;{{ site.time | date: " 2015, %Y"  }} ThoughtSpot, Inc. All rights reserved.
 
 ThoughtSpot, Inc. 910 Hermosa Ct, Sunnyvale, CA 94085
 


### PR DESCRIPTION
### What's changed:
- Automated copyright date on docs copyright page

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>