### PR TITLE
Automated copyright date on docs copyright page

### DIFF
--- a/_admin/misc/copyright.md
+++ b/_admin/misc/copyright.md
@@ -7,7 +7,7 @@ permalink: /:collection/:path.html
 ---
 Copyright for ThoughtSpot publications.
 
-&copy;{{ site.time | date: " 2015, %Y"  }} ThoughtSpot, Inc. All rights reserved.
+&copy;{{ site.time | date: " 2015, %Y" }} ThoughtSpot, Inc. All rights reserved.
 
 ThoughtSpot, Inc. 910 Hermosa Ct, Sunnyvale, CA 94085
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
    <div class="row">
       <div class="col-lg-12 footer">
         Generated: {{ site.time | date: "%b %-d, %Y"  }} <br />
-         &copy;{{ site.time | date: " 2015, %Y"  }} {{site.company_name}}.  All rights reserved. <br />
+         &copy;{{ site.time | date: " 2015, %Y" }} {{site.company_name}}.  All rights reserved. <br />
          <!-- {% if page.last_updated %}<span>Page last updated:</span> {{page.last_updated}}<br/>{% endif %}  -->
          <p><img style="width:100px;" src="{{ "images/company_logo.png" | absolute_url }}" alt="Company logo"/></p>
       </div>


### PR DESCRIPTION
### What's changed:
- Automated copyright date on docs copyright page.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>