### PR TITLE
5.1 site update to allow navigation to latest 5.2

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -14,8 +14,8 @@ topnav_dropdowns:
   sections:
     - title: Version
       sectionitems:
-        - title: latest (5.1)
-          url: /5.1/index.html
+        - title: latest (5.2)
+          url: /5.2/index.html
         - title: 5.0
           url: /5.0/index.html
         - title: 4.5

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -8,7 +8,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="fa fa-home fa-lg navbar-brand" href="{{ "/index.html" | prepend: site.baseurl }}">&nbsp;<span class="projectTitle"> {{site.topnav_title}}</span></a>
+            <a class="fa fa-home fa-lg navbar-brand" href="https://docs.thoughtspot.com/">&nbsp;<span class="projectTitle"> {{site.topnav_title}}</span></a>
         </div>
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
### What's changed:
- Fixed home icon and "latest" in version drop-down to point to latest 5.2 site.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>