### PR TITLE
Update vmware-setup.md to include missing steps

### DIFF
--- a/_appliance/vmware/vmware-setup.md
+++ b/_appliance/vmware/vmware-setup.md
@@ -141,6 +141,10 @@ additional, larger capacity disks.
 
 ## Next steps
 
-There is no network at this point on your VMs. To make the VM node accessible
-from any terminal within local network, contact <a
-href="mailto:support@thoughtspot.com">support@thoughtspot.com</a>.
+There is no network at this point on your VMs. As a prerequisite:
+
+1. Verify that Network Adapter type is set to VMware vmxnet3 (Recommended).
+2. Verify that all ESX host that all ThoughtSpot VM are running on (or, can run on) have been trunked to the VLAN assigned to TS VM(s).
+3. Verify that console for all ThoghtSpot VMs is accessible vim VMware vCenter server.
+
+Once done, go to <a href="http://support.thoughtspot.com">ThoughtSpot Support website</a> and use the support ticket meant for installation task. If necessary, create a new ticket.

--- a/_appliance/vmware/vmware-setup.md
+++ b/_appliance/vmware/vmware-setup.md
@@ -144,7 +144,7 @@ additional, larger capacity disks.
 There is no network at this point on your VMs. As a prerequisite:
 
 1. Verify that Network Adapter type is set to VMware vmxnet3 (Recommended).
-2. Verify that all ESX host that all ThoughtSpot VM are running on (or, can run on) have been trunked to the VLAN assigned to TS VM(s).
-3. Verify that console for all ThoghtSpot VMs is accessible vim VMware vCenter server.
+2. Verify that all ESXi hosts in your VMware farm for ThoughtSpot have been trunked to the VLAN assigned to your ThoughtSpot VMs.
+3. Verify that the console of all ThoughtSpot VMs is accessible in VMware vCenter Server.
 
-Once done, go to <a href="http://support.thoughtspot.com">ThoughtSpot Support website</a> and use the support ticket meant for installation task. If necessary, create a new ticket.
+Once done, go to the <a href="http://support.thoughtspot.com">ThoughtSpot Support website</a> and use the support ticket for installation tasks. If necessary, create a new ticket.


### PR DESCRIPTION
Changes.
1. Added prerequisites for customers to check before reaching out to SRE for onlining VMs, including network adapter type as agreed in Slack conversation : https://thoughtspot.slack.com/archives/C03R64YB1/p1559067002040200?thread_ts=1558700907.008300&cid=C03R64YB1
2. Changed the URL so customers use http://support.thoughtspot.com (preferred method) instead of sending emails.

Please review and merge. Feel free to contact me (Rohit) via Slack if needed.