### PR TITLE
Added a section about SSL ciphers

### DIFF
--- a/_admin/setup/SSL-config.md
+++ b/_admin/setup/SSL-config.md
@@ -72,3 +72,10 @@ ThoughtSpot supports SSL v3, TLS v1.0, and TLS v1.1 for backwards compatibility.
     ```
 
     This will block all usage of older versions.
+
+## Supported SSL ciphers
+The types of SSL ciphers supported by webserver(s) in your ThoughtSpot instance can be listed by running the following command on any ThoughtSpot node (Not against the load-balancer).
+    ```
+    nmap --script ssl-enum-ciphers -p 443 <ThoughtSpot_node_IP_address>
+    ```
+You will need to ensure that your load-balancer supports these ciphers.


### PR DESCRIPTION
Customers need to be able to deduce the names of supported SSL ciphers on ThoughtSpot web service as they need to make sure that their implementation of load-balancer is equipped to connect to TS web services securely.

The command I've provided will allow customers to deduce the list of ciphers supported, right from the cluster.
I suggest this approach based on the lessons we've learned from working with Metropolitan Police and Nationwide Building Society, UK.

@mark-plummer  - I always create a new branch for my changes to docs. Please feel free to merge and close these branches as you go. CC @aliciaavrach