### PR TITLE
SEO fix for only the homepage

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -49,6 +49,8 @@
 {% elsif page.url contains site.current_version %}
 <!-- SEO Tools -->
 {% seo %}
+{% elsif page.url == "/" or page.url == "" %}
+{% seo %}
 {% else %}
 <meta name="robots" content="noindex" />
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Alicia Avrach <alicia@thoughtspot.com>
Set SEO logic to index if the page is the top level home page.