### PR TITLE
Fixed sidebar reference section to Stop Words

### DIFF
--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -1305,7 +1305,7 @@ entries:
     - title: User action codes reference
       url: /reference/action-codes.html
       output: web,refGdAdmin
-    - tilte: Stop word reference
+    - title: Stop word reference
       url: /reference/stop-words.html
       output: web,refGD
     - title: Error codes reference


### PR DESCRIPTION
### What's changed:
- Corrected typo in mydoc_sidebar.yml so **Stop word reference** now appears under **Reference** in left-hand nav.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>