### PR TITLE
Update to 5.2 release notes

### DIFF
--- a/_release/notes.md
+++ b/_release/notes.md
@@ -21,7 +21,6 @@ fixed issues from the previous releases, and any known issues.
 If you are running one of the following versions, you can upgrade to the 5.2 release
 directly:
 
-* 4.5.x to 5.2
 * 5.0.x to 5.2
 * 5.1.x to 5.2
 


### PR DESCRIPTION
### What's changed:
- Update to 5.2 release notes to remove upgrade path 4.5.x to 5.2 (per guidance from Manohar)

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>