### PR TITLE
Modifications about cipher/http sizes

### DIFF
--- a/_admin/setup/about-load-balancer-configuration.md
+++ b/_admin/setup/about-load-balancer-configuration.md
@@ -44,3 +44,12 @@ In order for session affinity to work on ThoughtSpot, HTTPS (an SSL certificate)
 You can access ThoughtSpot through any standard web proxy server. Web proxies are fairly universal regardless of the application they are proxying. However, ThoughtSpot doesn't use any new protocols, like SPDY or HTTP/2, which may have a dependency on the proxy. Instead, ThoughtSpot is commonly placed behind a web HTTP/HTTPS proxy.
 
 Additionally, the proxy can round robin across multiple nodes in the ThoughtSpot backend. You can essentially use the web proxy as a load balancer. Therefore, your session will carry over if the proxy round robins between the ThoughtSpot backends as long as the URL doesn’t change.
+
+## Parameters to be set on load balancer devices / application proxy servers
+
+### Maximum size of HTTP POST request
+Some load balancers / proxy solutions impose a defaul limit on the size of HTTP POST requests. In some cases it can be as low as 1 MB. 
+ThoughtSpot advises it to be set to 50 MB so please configure your device accordingly.
+
+### Encryption cipher suites on load balancer (server side).
+Please see https://docs.thoughtspot.com/5.2/admin/setup/SSL-config.html#supported-ssl-ciphers 

--- a/_admin/setup/about-load-balancer-configuration.md
+++ b/_admin/setup/about-load-balancer-configuration.md
@@ -48,8 +48,8 @@ Additionally, the proxy can round robin across multiple nodes in the ThoughtSpot
 ## Parameters to be set on load balancer devices / application proxy servers
 
 ### Maximum size of HTTP POST request
-Some load balancers / proxy solutions impose a defaul limit on the size of HTTP POST requests. In some cases it can be as low as 1 MB. 
+Some load balancers / proxy solutions impose a default limit on the size of HTTP POST requests. In some cases it can be as low as 1 MB. 
 ThoughtSpot advises it to be set to 50 MB so please configure your device accordingly.
 
 ### Encryption cipher suites on load balancer (server side).
-Please see https://docs.thoughtspot.com/5.2/admin/setup/SSL-config.html#supported-ssl-ciphers 
+Please see [Supported SSL ciphers]({{ site.baseurl }}/admin/setup/SSL-config.html#supported-ssl-ciphers)


### PR DESCRIPTION
Added bits about maximum size of HTTP post request from Slack conversation: https://thoughtspot.slack.com/archives/C03R64YB1/p1559985327146500?thread_ts=1559913077.114800&cid=C03R64YB1

Added bits about SSL ciphers based on SRE team's experience with Met police and Nationwide Building Society UK.
@mark-plummer - Please note that the URL in section "Encryption cipher suites on load balancer (server side)." needs to be made portable. Main reference is on https://docs.thoughtspot.com/5.2/admin/setup/SSL-config.html

Feel free to delete this github branch once you're done merging/publishing the doc. Thanks.