### PR TITLE
Updated custom calendar docs to tell customers to contact support for…

### DIFF
--- a/_admin/setup/set-custom-calendar.md
+++ b/_admin/setup/set-custom-calendar.md
@@ -2,7 +2,7 @@
 title: [Set up a fiscal calendar year]
 keywords: [fiscal calendar, fiscal calendar year, custom calendar]
 tags: [dates]
-summary: "You can customize your fiscal calendar to start in month other than January."
+summary: "You can customize your fiscal calendar to start in a month other than January."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
@@ -28,11 +28,7 @@ Before you create your custom calendar, you must enable the custom calendar feat
 
 ### Enabling the custom calendar feature
 
-To enable the custom calendar feature for your cluster, do the following:
-
-1. SSH into your ThoughtSpot cluster as admin.
-
-2. Run the following command: `tscli service add-javaopt tomcat.tomcat D orion.customCalendarConfig.enabled true`
+To enable the custom calendar feature for your cluster, contact [ThoughtSpot Support]({{ site.baseurl }}/admin/misc/contact.html#).
 
 ### Creating a custom calendar
 
@@ -74,15 +70,7 @@ Example calendar with the fiscal year beginning on April 1:
 
 ### (Optional) Setting a custom calendar as the default calendar for a cluster
 
-To set your custom calendar as the default calendar for your cluster, do the following:
-
-1. SSH into your ThoughtSpot cluster as admin.
-
-2. Run the following command:
-   `tscli service add-javaopt tomcat.tomcat D orion.customCalendarConfig.defaultClusterCalendar <calendar_name>`
-
-   Example:
-   `tscli service add-javaopt tomcat.tomcat D orion.customCalendarConfig.defaultClusterCalendar my_calendar`
+To set your custom calendar as the default calendar for your cluster, contact [ThoughtSpot Support]({{ site.baseurl }}/admin/misc/contact.html#).
 
 ### Using a custom calendar
 


### PR DESCRIPTION
### What's changed:
- Updated custom calendar docs to tell customers to contact support for enabling the feature, and setting a custom calendar as the default calendar for a cluster.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>