### PR TITLE
Update to Configure support page to use tunnelrelay.thoughtspot.com

### DIFF
--- a/_admin/setup/work-with-ts-support.md
+++ b/_admin/setup/work-with-ts-support.md
@@ -41,7 +41,7 @@ To enable remote support:
     remote tunnel.
 
     ```
-    $ tscli support set-remote --addr tunnel.thoughtspot.com --user ubuntu
+    $ tscli support set-remote --addr tunnelrelay.thoughtspot.com --user ubuntu
     ```
 
 5. Test that the setting is configured:


### PR DESCRIPTION
### What's changed:
- Update to Configure support page to use tunnelrelay.thoughtspot.com instead of tunnel.thoughtspot.com (per guidance from Nickloas Klue)

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>