### PR TITLE
Removing Help Center from doc site nav bar

### DIFF
--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -1323,9 +1323,6 @@ entries:
   - sectiontitle: About this Release
     output: web,rnotes
     sectionitems:
-    - title: Help Center
-      url: /release/help-center.html
-      output: web
     - title: Release notes
       url: /release/notes.html
       output: web,rnotes


### PR DESCRIPTION
### What's changed:
- Removed Help Center from the About this Release drop-down

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>