### PR TITLE
fixed onboarding entries in mydoc sidebar that caused site build failure

### DIFF
--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -46,12 +46,12 @@ entries:
     - levelTwoTitle: Onboarding
       output: web,ugBk
       levelTwoItems:
-        -title: Introduction to onboarding
-         url: /end-user/onboarding/intro-onboarding.html
-         output: web,ugBk
-       - title: User onboarding experience
-         url: /end-user/onboarding/user-onboarding-experience.html
-         output: web,ugBk
+      - title: Introduction to onboarding
+        url: /end-user/onboarding/intro-onboarding.html
+        output: web,ugBk
+      - title: User onboarding experience
+        url: /end-user/onboarding/user-onboarding-experience.html
+        output: web,ugBk
     - levelTwoTitle: Use Search
       output: web,ugBk
       levelTwoItems:


### PR DESCRIPTION
### What's changed:
- Fixed spacing and hyphen issues in Onboarding entries in mydoc sidebar that were causing Jekyll site build to fail.
 

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>