### PR TITLE
Removing out-of-date information from AWS content

### DIFF
--- a/_appliance/aws/configuration-options.md
+++ b/_appliance/aws/configuration-options.md
@@ -6,14 +6,14 @@ last_updated: tbd
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-ThoughtSpot engineering has performed extensive testing of the ThoughtSpot
-application on the Amazon Elastic Compute Cloud (EC2) platform, including both Amazon Elastic Block
-Store (EBS) and S3 storage configurations for the best performance, scalability,
-reliability, and cost savings.
-
-You can find information here on which configuration of memory, CPU, storage,
-and networking capacity you should be running for your instances. There are also
-details on how to configure your placement groups.
+This page includes details on the following configuration options for AWS instances:
+- Storage
+- Memory
+- CPU
+- Networking
+- Regions
+- Availability zones
+- Placement groups
 
 ## Storage options
 

--- a/_appliance/aws/launch-an-instance.md
+++ b/_appliance/aws/launch-an-instance.md
@@ -36,7 +36,6 @@ ThoughtSpot instances on AWS need AWS EC2 instances to be provisioned in the AWS
 **AMI Name**: thoughtspot-image-20190718-dda1cc60a58-prod   
 **AMI ID**: ami-0b23846e4761375f1  
 **Region**: N. California
-- For customers with smaller data sets, a custom AMI (Name = centos-golden-20181023-4d9ee24-prod-small, ID = ami-06138062df81bdaf7) has also been made available. VMs based on this configuration will suffice for data sizes up to 100 GB/node.
 - Choose the appropriate EC2 instance type: See [ThoughtSpot AWS instance types]({{ site.baseurl }}/appliance/aws/configuration-options.html#thoughtspot-aws-instance-types) for supported instance types.
 - Networking requirements: 10 GbE network bandwidth is needed between the VMs. This is the default for the VM type recommended by ThoughtSpot.
 - Security: The VMs that are part of a cluster need to be accessible by each other, which means they need to be on the same Amazon Virtual Private Cloud (VPC) and subnetwork. Additional external access may be required to bring data in/out of the VMs to your network.


### PR DESCRIPTION
### What's changed:
- Removed out-of-date prerequisite from Set up AWS topic
- Removed superfluous information about EBS from AWS Configuration options page
- Reworked intro paragraph on AWS configuration options page

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>