### PR TITLE
Minor amendment "tscli command run..."

### DIFF
--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -240,7 +240,7 @@ Command to run a command on all nodes.
 *`COPYFIRST`*`] [--timeout` *`TIMEOUT`*`]` *`command`*
 
 * `--nodes` *`NODES`*  Space separated IPs of nodes where you want to run the command. (default: `all`)
-* `--dest_dir` *`DEST_DIR`*  Directory to save the files containing output from each nodes. (default: None)
+* `--dest_dir` *`DEST_DIR`*  Directory to save the files containing output from each nodes. (Mandatory. Default: None)
 * `--copyfirst` *`COPYFIRST`* Copy the executable to required nodes first. (default: `False`)
 * `--timeout` *`TIMEOUT`* Timeout waiting for the command to finish. (default: `60`)
 

--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -240,7 +240,7 @@ Command to run a command on all nodes.
 *`COPYFIRST`*`] [--timeout` *`TIMEOUT`*`]` *`command`*
 
 * `--nodes` *`NODES`*  Space separated IPs of nodes where you want to run the command. (default: `all`)
-* `--dest_dir` *`DEST_DIR`*  Directory to save the files containing output from each nodes. (Mandatory. Default: None)
+* `--dest_dir` *`DEST_DIR`*  Directory to save the files containing output from each nodes. (Required. Default: None)
 * `--copyfirst` *`COPYFIRST`* Copy the executable to required nodes first. (default: `False`)
 * `--timeout` *`TIMEOUT`* Timeout waiting for the command to finish. (default: `60`)
 


### PR DESCRIPTION
Current documentation for "tscli command run" says that "--dest_dir" is needed but this parameter isn't optional and it doesn't have a default value, so if we just run the command without specifying it, we run into an error as demonstrated below.
```
[admin@dogfood1 ~]$ tscli command run 'df -h'
usage: tscli command run [-h] [--nodes NODES] --dest_dir DEST_DIR
                         [--copyfirst COPYFIRST] [--timeout TIMEOUT]
                         command
tscli command run: error: argument --dest_dir is required
```

I'm asking to make it very clear to the user that this flag is mandatory.