### PR TITLE
fixed incorrect cpu/ram numbers in azure and gcp instance tables

### DIFF
--- a/_appliance/azure/configuration-options.md
+++ b/_appliance/azure/configuration-options.md
@@ -15,7 +15,7 @@ All Azure VMs (nodes) in a ThoughtSpot cluster must be in the same availability 
 
 | Per VM user data capacity | Instance type | CPU/RAM | Recommended per-VM <br>Premium SSD Managed Disk volume |
 | --- | --- | --- |--- |
-| 200 GB | E64sv3 | 64/416 | 2x1 TB |
+| 200 GB | E64sv3 | 64/432 | 2x1 TB |
 | 100 GB | E32sv3 | 32/256 | 2X 400 GB |
 | 20 GB | E16sv3 | 16/128 | 2X 400 GB |
 | 120 GB | D64v3 | 64/256 | 2X 1 TB |

--- a/_appliance/cloud.md
+++ b/_appliance/cloud.md
@@ -15,8 +15,8 @@ The ThoughtSpot cloud deployment consists of cloud compute (VM) instances and an
 
 | | AWS | Azure | GCP |
 | --- | --- | --- | --- |
-| <b>Compute<b> | Virtual Machines deployed in your<br>AWS VPC | Virtual Machines in your<br>Azure VNET | Virtual Machines in your<br>GCP VPC |
-| <b>Persistent <br>storage<b> | Two deployment options:<br>1. Elastic Block Storage<br>2. AWS + Elastic Block Storage | Premium SSD Managed Disks | Zonal SSD persistent disk |
+| <b>Compute<b> | Virtual machines deployed in your<br>AWS VPC | Virtual machines in your<br>Azure VNET | Virtual machines in your<br>GCP VPC |
+| <b>Persistent <br>storage<b> | Deployment options:<br>1. Elastic Block Storage<br>2. S3 + Elastic Block Storage | Premium SSD Managed Disks | Zonal SSD persistent disk |
 
 ![]({{ site.baseurl }}/images/cloud-vm-storage.svg "ThoughtSpot cloud deployment")
 

--- a/_appliance/gcp/configuration-options.md
+++ b/_appliance/gcp/configuration-options.md
@@ -17,8 +17,6 @@ All GCP VMs (nodes) in a ThoughtSpot cluster must be in the same zone
 | --- | --- | --- |--- |
 | 208 GB | n1-highmem-64 | 64/416 | 2x 1 TB |
 | 312 GB | n1-highmem-96 | 96/624 | 2x 1.5 TB |
-| 100 GB | n1-highmem-32 | 16/104 | 2X 400 GB |
+| 100 GB | n1-highmem-32 | 32/208 | 2X 400 GB |
 | 20 GB | n1-highmem-16 | 16/122 | 2X 400 GB |
-| 180 GB | n1-standard-96 | 96/330 | 2X 1 TB |
-
-GCP provides several storage types and media options. ThoughtSpot requires [attached storage](https://cloud.google.com/compute/docs/disks/) and persistent disks.        
+| 180 GB | n1-standard-96 | 96/330 | 2X 1 TB |    


### PR DESCRIPTION
### What's changed:
- Fixed incorrect cpu/ram numbers in azure and gcp instance tables
- Minor copyedits

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>