### PR TITLE
Adding self-serve steps for TS side setup

### DIFF
--- a/_data-integrate/introduction/introduction-data-integration.md
+++ b/_data-integrate/introduction/introduction-data-integration.md
@@ -72,6 +72,17 @@ each method:
   </tbody>
 </table>
 
+## ThoughtSpot server-side setup prerequisites for importing data via JDBC/ODBC 
+Open up ThoughtSpot firewall to allow incoming requests to Simba server.
+```
+tscli firewall open-ports --ports 12345
+```
+Confirm that process `simba_server` is up. Output of the command below should contain exactly 1-line, as shown below.
+```
+ps -ef | grep simba_server | grep -v grep
+admin    26679 25672  0 Jul13 ?        00:01:49 simba_server_main --logbufsecs=0
+```
+Please reach out to ThoughtSpot Support Team should you require any help here.
 
 ## Where to go next
 


### PR DESCRIPTION
The steps I have added above in section "## ThoughtSpot server-side setup prerequisites for importing data via JDBC/ODBC" ideally belong in a separate section.
This section needs to be created on a page of its own and should be listed before the items "About the ODBC driver" and "About the JDBC driver", ultimately we should have 3 entries in "## Where to go next",

Can you take care of that Mark?
I am confident about editing pages inline but not sure how I can create a new one in GitHub without breaking anything.