### PR TITLE
Modify the doc to indicate multi-node setup

### DIFF
--- a/_data-integrate/clients/install-odbc-windows.md
+++ b/_data-integrate/clients/install-odbc-windows.md
@@ -162,7 +162,7 @@ privileges on the application.
 Now, you are ready to begin using the connection you've configured.
 
 
-## Related information
+## Related information 
 
 * [Enable ODBC logs]({{ site.baseurl}}/data-integrate/troubleshooting/enable-ODBC-log.html).
 * [Configure multiple connections on Windows]({{ site.baseurl}}/data-integrate/clients/multiple-sources-windows.html).


### PR DESCRIPTION
Customers follow this document and set up 1 IP address in their setup even for multi-node clusters.
When that node goes down, they have a P0 incident as data loads are blocked.
This can easily be avoided.
Modify as follows:-

1. https://docs.thoughtspot.com/5.2/data-integrate/clients/install-odbc-windows.html#check-the-thoughtspot-ip-and-the-simba_server-status : Instead of listing 1 IP address in the output of `tscli node ls`, list 2 IPs.
2. In the same section, need to delete "Verify that the simba_server is running, if it isn’t, work with ThoughtSpot Support to start it.". simba_service now runs by default on one node in the cluster. Customer shouldn't be raising tickets for this unless there's a real issue.
3. Instead add the following line "Configure ThoughtSpot firewall to allow connections from your ETL client by running the following command on any one ThoughtSpot node."
The command is "tscli firewall open-ports --ports 12345".

Modify section "https://docs.thoughtspot.com/5.2/data-integrate/clients/install-odbc-windows.html#configure-the-driver-and-test-your-connection".

The image followed by comment "For Server(s), provide a comma separated list of the IP addresses of each node on the ThoughtSpot instance." needs to show 2 or more fully qualified hostnames or IP addresses (comma separated) to make a point that this connection is setup with HA.

Similarly the image (Client Configuration Dialogue) after "Select ThoughtSpot and press Configure." needs to be an example having more than 1 IP addresses.