### PR TITLE
Sort instance types intuitively

### DIFF
--- a/_appliance/aws/configuration-options.md
+++ b/_appliance/aws/configuration-options.md
@@ -44,7 +44,7 @@ details on how to configure your placement groups.
 	  <td><p dir="ltr"><strong>Boot volume</strong></p></td>
 	  <td><p dir="ltr"><strong>Data volumes</strong></p></td>
     </tr>
-    <tr>
+    <tr> 
       <td><p dir="ltr">Standard</p>
         <p dir="ltr">(1KB/row)</p></td>
       <td><p dir="ltr">Up to 2 TB </p></td>


### PR DESCRIPTION
1. Sort the table "AWS instance type" by capacity. Currently we have >2TB embedded between the rows of 2TB and 100GB. It should be at the very top.
2. Clearly indicate data shape ((1KB/row)) to all instance types/capacities that it applies to. Currently it appears that only first and last row have data shape associated while the rest are blank.

Customers are asking CS and CS are asking SREs to understand the docs. :-)
Let us fix this at a priority please.