### PR TITLE
Minor fixes to AWS configuration options page

### DIFF
--- a/_appliance/aws/configuration-options.md
+++ b/_appliance/aws/configuration-options.md
@@ -29,21 +29,6 @@ The cost of infrastructure for deploying ThoughtSpot is cheaper when using S3. H
       <td>In EBS</td>
       <td>In EBS</td>
     </tr>
-    <tr>
-      <td>Snapshots</td>
-      <td>In EBS</td>
-      <td>In EBS</td>
-    </tr>
-    <tr>
-      <td>Backups<b>*</b></td>
-      <td>In EBS</td>
-      <td>In EBS</td>
-    </tr>
-    <tr>
-      <td colspan="3"><b>*</b>For details on how to back up your ThoughtSpot instance, see <a href="/admin/backup-restore/take-backup.html#">Create a manual backup</a>.</td>
-      <td>&nbsp;</td>
-      <td>&nbsp;</td>
-    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
### What's changed:
- Removed redundant row from first table
- Removed row about backups from first table

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>