### PR TITLE
Update to 'command' command in tscli command reference

### DIFF
--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -240,7 +240,7 @@ Command to run a command on all nodes.
 *`COPYFIRST`*`] [--timeout` *`TIMEOUT`*`]` *`command`*
 
 * `--nodes` *`NODES`*  Space separated IPs of nodes where you want to run the command. (default: `all`)
-* `--dest_dir` *`DEST_DIR`*  Directory to save the files containing output from each nodes. (default: None)
+* `--dest_dir` *`DEST_DIR`*  Directory to save the files containing output from each nodes. (required. default: None)
 * `--copyfirst` *`COPYFIRST`* Copy the executable to required nodes first. (default: `False`)
 * `--timeout` *`TIMEOUT`* Timeout waiting for the command to finish. (default: `60`)
 


### PR DESCRIPTION
### What's changed:
- Added note about `-dest dir` being required with `tscli command run` (rohit's pull request: #1091)

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>