### PR TITLE
What is the size of boot disk? 200GB or 250GB

### DIFF
--- a/_appliance/gcp/launch-an-instance.md
+++ b/_appliance/gcp/launch-an-instance.md
@@ -27,7 +27,7 @@ In a nutshell, the required configuration ThoughtSpot is:
 
 - 64 vCPU
 - 416 GB RAM
-- 200 GB SSD for the boot disk, provisioned with a ThoughtSpot base image
+- GB SSD for the boot disk, provisioned with a ThoughtSpot base image
 - Two 1 TB SSDs for data
 
 The following topics walk you through this process.


### PR DESCRIPTION
The docs say 200GB in 2 places but a customer reported yesterday that adding the disk translates to 250GB req that can't be lowered.
Additionally, observation from SRE team is the same https://thoughtspot.atlassian.net/wiki/spaces/SRE/pages/407240807/GCP+Thoughtspot+Installation