### PR TITLE
Updated GCP boot disk requirement

### DIFF
--- a/_appliance/gcp/launch-an-instance.md
+++ b/_appliance/gcp/launch-an-instance.md
@@ -64,7 +64,7 @@ The following topics walk you through this process.
       |------------     | --------------------      |
       | Image           | `ThoughtSpot`             |
       | Boot disk type  | `Standard persistent disk`|
-      | Size (GB)       | `200`                     |
+      | Size (GB)       | `250`                     |
 
       ![]({{ site.baseurl }}/images/gcp-5-boot-disk-config-2018-01-11.png "Change boot disk")
 


### PR DESCRIPTION
### What's changed:
- Updated GCP boot disk req from 200 to 250 GB per guidance from Rohit's PR #1123 and confirmation from Sameer

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>