### PR TITLE
Changed 'press' to 'click' in procedures on site

### DIFF
--- a/_admin/setup/customize-style.md
+++ b/_admin/setup/customize-style.md
@@ -91,11 +91,11 @@ To set a new font:
 
 2. Select the label you want to change.
 
-3. Press the **+** button.
+3. Click the **+** button.
 
    The system displays the **Custom Font** dialog.
 
-4. Press the **Custom Font** field.
+4. Click the **Custom Font** field.
 
    The system displays the file finder.
 
@@ -103,7 +103,7 @@ To set a new font:
 
    The file appears in the font dialog
 
-6. Press **Save** to change the font.
+6. Click **Save** to change the font.
 
 ## How to specify the behavior or clickable links in data
 

--- a/_appliance/vmware/vmware-setup.md
+++ b/_appliance/vmware/vmware-setup.md
@@ -25,7 +25,7 @@ for a sandbox environment but is insufficient for a production environment.
    physical host has more than 72 cores, you may want to edit VM to have (`n-2`)
    cores (for a physical host with n cores) to fully take advantage of computing
    power of the physical host. Extra cores help performance.
-   
+
    You should aim to allocate 490 GB or more RAM.
 
 2. Create datastores for all solid-state drive (SSD) and hard drive devices.
@@ -43,15 +43,15 @@ for a sandbox environment but is insufficient for a production environment.
 
    ![]({{ site.baseurl }}/images/vmware-ovf.png "ThoughtSpot OVF")
 
-3. Choose the OVF template and press **Next**.
+3. Choose the OVF template and click **Next**.
 
    The system prompts you to select a storage.
 
-4. Choose the SSD as the destination and press **Next**.
+4. Choose the SSD as the destination and click **Next**.
 
    The system displays the **Deployment Options** dialog.
 
-5. Enter the options and press **Next**.
+5. Enter the options and click **Next**.
 
     | Setting                    | Value                                             |
     |----------------------------|---------------------------------------------------|
@@ -59,7 +59,7 @@ for a sandbox environment but is insufficient for a production environment.
     | **Disk provisioning**      | Choose Thin.                                      |
     | **Power on automatically** | Check this box.                                   |
 
-6. Review your selection and press **Finish**.
+6. Review your selection and click **Finish**.
 
    ![]({{ site.baseurl }}/images/vmware-complete.png "Complete")
 

--- a/_data-integrate/clients/multiple-sources-windows.md
+++ b/_data-integrate/clients/multiple-sources-windows.md
@@ -58,11 +58,11 @@ or development cluster.
 
     ![]({{ site.baseurl }}/images/ODBC_add_custom_property_new_data_source.png "Enter the custom property key and value")
 
-9. When you are done, press **OK** to save your new configuration.
+9. When you are done, click **OK** to save your new configuration.
 
     ![]({{ site.baseurl }}/images/odbc-new-config.png "Success")
 
-10. Press **Test Connection** to test your database connection.
+10. Click **Test Connection** to test your database connection.
 
     ![]({{ site.baseurl }}/images/windows-odbc-success.png "Success")
 
@@ -71,6 +71,6 @@ or development cluster.
     }}/data-integrate/troubleshooting/enable-ODBC-log.html#) to
     troubleshoot.
 
-11. Press **Cancel** to close the **DSN Configuration** dialog.
-12. Press **OK** to close the **Client Configuration Dialog** the dialog.
-13. Press **OK** to close the **ODBC Data Source Administrator (64-bit)** application
+11. Click **Cancel** to close the **DSN Configuration** dialog.
+12. Click **OK** to close the **Client Configuration Dialog** the dialog.
+13. Click **OK** to close the **ODBC Data Source Administrator (64-bit)** application

--- a/_data-integrate/clients/windows-deploy-ssl.md
+++ b/_data-integrate/clients/windows-deploy-ssl.md
@@ -88,7 +88,7 @@ and then test the connection.
     ![]({{ site.baseurl }}/images/windows-odbc-custom-CACert-property.png "client settings")
     ![]({{ site.baseurl }}/images/windows-odbc-cert-and-SSL.png "client settings")
 
-6. When you are done, press **OK** to save your new properties.
+6. When you are done, click **OK** to save your new properties.
 7. Click **Test Connection** to test your database connection.
 
     ![]({{ site.baseurl }}/images/windows-odbc-success.png "Success")


### PR DESCRIPTION
### What's changed:
- Updated procedure in Configure multiple connections on Windows, to use 'click' instead of 'press' in the UI
- Did the same for other instances of this across the 5.2 site

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>