### PR TITLE
Make core/vCPU count consistent

### DIFF
--- a/_appliance/vmware/vmware-setup.md
+++ b/_appliance/vmware/vmware-setup.md
@@ -24,7 +24,8 @@ for a sandbox environment but is insufficient for a production environment.
    The VM template, by default, captures a 72-core configuration. If your
    physical host has more than 72 cores, you may want to edit VM to have (`n-2`)
    cores (for a physical host with n cores) to fully take advantage of computing
-   power of the physical host. Extra cores help performance.
+   power of the physical host. Extra cores help performance. If your hypervisor
+   has 72 hyperthreaded cores, ThoughtSpot VM should be configured to use 70.
 
    You should aim to allocate 490 GB or more RAM.
 


### PR DESCRIPTION
Hi Mark,

The parent page "Cofiguration overview"  says that the hypervisor should have 72 cores minimum.
However "Set up VMware for ThoughtSpot" page says that the VM OVA by default accepts 72 cores and can take more if available.
So customers become unsure whether 72 cores on a HV are sufficient or not?

We should either change default OVA config to use 70 cores - or
Change hypervisor spec to 74 cores (so that N-2 = 72, as needed by VM).
Or at least add to this document a screenshot about what the configuration will look like when a VM using 70 HT cores is configured for a hypervisor having 72 HT cores. 

Need to give customers clear indication of what to buy and how it will fit together.

I've also added my suggestion (if HV has 72 cores, VM should be configured to use 70). Please run it by Satyam for signoff.