### PR TITLE
Validation information for AD SSL certificate

### DIFF
--- a/_admin/setup/add-SSL-for-LDAP.md
+++ b/_admin/setup/add-SSL-for-LDAP.md
@@ -11,10 +11,10 @@ When you set up LDAP, you specified whether or not to use SSL for LDAP (LDAPS). 
 
 You must have the SSL certificate before you start. For more information on obtaining an SSL certificate, see [Configure SSL (secure socket layers)](SSL-config.html#).
 
-As of the current ThoughtSpot software version:-
-1. You should configure only one SSL certificate in ThoughtSpot for Active Directory.
-2. The Common Name (CN) in the SSL certificate should match the one provided to `tscli ldap configure` earlier.
-3. Only top-level SSL certificate is necessary. Root certificate or any intermediate certificates are not needed.
+As of the current ThoughtSpot software version:
+1. You must configure only one SSL certificate in ThoughtSpot for Active Directory.
+2. The Common Name (CN) in the SSL certificate must match the one provided to `tscli ldap configure` earlier.
+3. Only the top-level SSL certificate is necessary. The root or any intermediate certificates are not required.
 
 To add the SSL certificate for LDAP:
 

--- a/_admin/setup/add-SSL-for-LDAP.md
+++ b/_admin/setup/add-SSL-for-LDAP.md
@@ -11,6 +11,11 @@ When you set up LDAP, you specified whether or not to use SSL for LDAP (LDAPS). 
 
 You must have the SSL certificate before you start. For more information on obtaining an SSL certificate, see [Configure SSL (secure socket layers)](SSL-config.html#).
 
+As of the current ThoughtSpot software version:-
+1. You should configure only one SSL certificate in ThoughtSpot for Active Directory.
+2. The Common Name (CN) in the SSL certificate should match the one provided to `tscli ldap configure` earlier.
+3. Only top-level SSL certificate is necessary. Root certificate or any intermediate certificates are not needed.
+
 To add the SSL certificate for LDAP:
 
 1. Follow the instructions from your certifying authority to obtain the certificate. This is usually sent via email or available by download.


### PR DESCRIPTION
Added validation information for AD SSL certificate. 
Payback (customer) followed the self-service instructions without the validations and landed themselves into a P0.