### PR TITLE
fixed mispelling of ThoughtSpot in mobile docs and other places

### DIFF
--- a/_admin/mobile/deploy-mobile.md
+++ b/_admin/mobile/deploy-mobile.md
@@ -5,7 +5,7 @@ last_updated: tbd
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-Deploying the ThoughSpot mobile app to your users allows them to access their data and make decisions remotely from their Apple iOS device. For more information about features in the mobile app, refer to [ThoughtSpot mobile overview]({{ site.baseurl }}/admin/mobile/use-mobile.html#).
+Deploying the ThoughtSpot mobile app to your users allows them to access their data and make decisions remotely from their Apple iOS device. For more information about features in the mobile app, refer to [ThoughtSpot mobile overview]({{ site.baseurl }}/admin/mobile/use-mobile.html#).
 
 ## Deployment options
 

--- a/_admin/mobile/use-mobile.md
+++ b/_admin/mobile/use-mobile.md
@@ -5,7 +5,7 @@ last_updated: tbd
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-ThoughSpot mobile app version 1.1 allows you to discover insights in seconds from billions of rows of data, right from the palm of your hand. You can access your ThoughtSpot cluster to search answers and pinboards. You can also create pinboards using existing answers and use pinboard filters.
+ThoughtSpot mobile app version 1.1 allows you to discover insights in seconds from billions of rows of data, right from the palm of your hand. You can access your ThoughtSpot cluster to search answers and pinboards. You can also create pinboards using existing answers and use pinboard filters.
 
 ## Requirements
 

--- a/_app-integrate/embedding-viz/embed-a-viz.md
+++ b/_app-integrate/embedding-viz/embed-a-viz.md
@@ -36,7 +36,7 @@ before continuing.
 
    The format for the link is:  `<protocol>:<host>:<port>/#/embed/viz/<pinboardID>`
 
-   For a vizualization in a pinboard, click the ellipses icon 
+   For a vizualization in a pinboard, click the ellipses icon
    ![more options menu icon]({{ site.baseurl }}/images/icon-ellipses.png){: .inline} >
     **Copy Link**.
 
@@ -60,7 +60,7 @@ embed a ThoughtSpot pinboard or visualization. For this example, you'll get a co
     Here are the fields in the `test.html` file you need to edit.
 
     ```JavaScript
-    var protocol = "THOUGHSPOT_PROTOCOL";
+    var protocol = "THOUGHTSPOT_PROTOCOL";
     var hostPort = "HOST_PORT";   
 
     var pinboardId = "PINBOARD_ID";

--- a/_appliance/aws/ha-aws-efs.md
+++ b/_appliance/aws/ha-aws-efs.md
@@ -7,7 +7,7 @@ permalink: /:collection/:path.html
 ---
 ## Setting up High Availability (HA) for your ThoughtSpot cluster using AWS Elastic File System (EFS)
 
-To set up HA for your ThoughSpot cluster, do the following:
+To set up HA for your ThoughtSpot cluster, do the following:
 
 1. Create EFS File System spanning across different availability zones and different subnets.
 

--- a/downloads/test.html
+++ b/downloads/test.html
@@ -35,7 +35,7 @@
 //// <protocol>:<host>:<port>/#/embed/viz/<pinboardID>/<vizualizationId> //////
 ///////////////////////////////////////////////////////////////////////////////
 
-  var protocol = "THOUGHSPOT_PROTOCOL"; // The protocol that appears in the pinboard/visualization link
+  var protocol = "THOUGHSTPOT_PROTOCOL"; // The protocol that appears in the pinboard/visualization link
   var hostPort = "HOST_PORT";   // Hostport info for ThoughtSpot app. Ex: <host>:<port> or <host>
 
   // Use Actions > Copy link from a pinboard or a visualization in a pinboard to get a link for embedding


### PR DESCRIPTION
### What's changed:
Fixed mispelling of ThoughtSpot in mobile docs and three other sections on doc site
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>