### PR TITLE
Reworked the document

### DIFF
--- a/_admin/setup/about-load-balancer-configuration.md
+++ b/_admin/setup/about-load-balancer-configuration.md
@@ -9,47 +9,33 @@ permalink: /:collection/:path.html
 ---
 Here are some of the best practices and guidelines for a typical implementation with ThoughtSpot. Your experience may differ depending on your environment and preference.
 
-## Load balance across ThoughtSpot nodes
+## Load balancing across ThoughtSpot nodes
 
 The following shows a network architectural diagram which includes a load balancer for ThoughtSpot nodes.
 
 ![]({{ site.baseurl }}/images/network_architectural_diagram.png)
 
-The load balancer is an appliance in your infrastructure that routes traffic automatically to nodes to provide failover. You can also place a load balancer or proxy in front of the ThoughtSpot appliance if you'd like external network users to access the system.
+The load balancer appliance/implementation manages traffic to back-end cluster nodes to provide failover & high-availability capabilities for a multi-node ThoughtSpot cluster. 
 
+Deploying a load balancer between users and ThoughtSpot cluster is highly recommended. 
+If you wish to setup CORS, SAML or Single-Sign-On for a multi-node ThoughtSpot cluster, setting up load balancer is a prerequisite. 
 
-The best way to load balance across all ThoughtSpot nodes in a cluster is to map one domain name (FQDN) to all the IPs in the cluster in a round robin fashion.
+## Typical configuration for load balancers
 
-For example, if you want to use a DNS server based load balancing, then you can define multiple "A" resource records (RR) for the same name.
-
-Below is an example of how you could set that up
-
-```
-thoughtspot.customer.com IN A 69.9.64.11
-thoughtspot.customer.com IN A 69.9.64.12
-thoughtspot.customer.com IN A 69.9.64.13
-thoughtspot.customer.com IN A 69.9.64.14
-```
-
-The example indicates that IP addresses for the domain thoughtspot.customer.com are 69.9.64.11, 69.9.64.12, 69.9.64.13, and 69.9.64.14.
-
-## Session Affinity
-
-Session Affinity refers to directing requests to the same application server for the time it takes to complete a task.
-
-In order for session affinity to work on ThoughtSpot, HTTPS (an SSL certificate) has to be installed on the load balancer level. If it is installed outside of the load balancer, session affinity may not occur and the ThoughtSpot system will fail.
+1. Session affinity: Having it turned-on by default helps retain established SSL sessions; instead of having to frequently renegotiate sessions between the load balancer and back-end nodes. This is the recommended setting.
+2. Maximum size of HTTP POST request: Some load balancers / proxy solutions impose a default limit (as low as 1MB) on the size of HTTP POST requests. ThoughtSpot requires it to be set to 50 MB (or as close to it as possible) so please confirm you've set this correctly.
+3. Server-side SSL profile needs to be enabled on load balancers.
+4. The following SSL ciphers need to be enabled on server-side SSL profile : [Supported SSL ciphers]({{ site.baseurl}}/admin/setup/SSL-config.html#supported-ssl-ciphers)
 
 ## Web proxies
 
-You can access ThoughtSpot through any standard web proxy server. Web proxies are fairly universal regardless of the application they are proxying. However, ThoughtSpot doesn't use any new protocols, like SPDY or HTTP/2, which may have a dependency on the proxy. Instead, ThoughtSpot is commonly placed behind a web HTTP/HTTPS proxy.
+You can access ThoughtSpot through any standard web proxy server. Web proxies are fairly universal regardless of the application they are proxying. 
+ThoughtSpot doesn't use any new protocols, like SPDY or HTTP/2, which may have a dependency on the proxy and as a result, ThoughtSpot is commonly placed behind a web HTTP/HTTPS proxy.
 
-Additionally, the proxy can round robin across multiple nodes in the ThoughtSpot backend. You can essentially use the web proxy as a load balancer. Therefore, your session will carry over if the proxy round robins between the ThoughtSpot backends as long as the URL doesn’t change.
+The proxy can also round-robin across the nodes in ThoughtSpot cluster in which case you are using the web proxy as a load balancer. Your session will carry over if the proxy round robins between the ThoughtSpot backends as long as the URL doesn’t change.
 
-## Parameters to be set on load balancer devices / application proxy servers
-
-### Maximum size of HTTP POST request
-Some load balancers / proxy solutions impose a default limit on the size of HTTP POST requests. In some cases it can be as low as 1 MB. 
-ThoughtSpot advises it to be set to 50 MB so please configure your device accordingly.
-
-### Encryption cipher suites on load balancer (server side).
-Please see [Supported SSL ciphers]({{ site.baseurl }}/admin/setup/SSL-config.html#supported-ssl-ciphers)
+## Alternatives
+One way to load balance across all ThoughtSpot nodes in a cluster is to map one domain name (FQDN) to all the IPs in the cluster in a round robin fashion. 
+This is no longer recommended because:-
+1. This is not suitable for secured (https) based access.
+2. DNS based round-robin isn't aware of state of backend nodes and can still send requests to nodes no longer in service. 

--- a/_admin/setup/about-load-balancer-configuration.md
+++ b/_admin/setup/about-load-balancer-configuration.md
@@ -15,27 +15,27 @@ The following shows a network architectural diagram which includes a load balanc
 
 ![]({{ site.baseurl }}/images/network_architectural_diagram.png)
 
-The load balancer appliance/implementation manages traffic to back-end cluster nodes to provide failover & high-availability capabilities for a multi-node ThoughtSpot cluster. 
+The load balancer appliance/implementation manages traffic to back-end cluster nodes to provide failover and high-availability capabilities for a multi-node ThoughtSpot cluster. 
 
-Deploying a load balancer between users and ThoughtSpot cluster is highly recommended. 
-If you wish to setup CORS, SAML or Single-Sign-On for a multi-node ThoughtSpot cluster, setting up load balancer is a prerequisite. 
+Deploying a load balancer between users and a ThoughtSpot cluster is highly recommended. 
+You must set up a load balancer before you can set up CORS, SAML or single sign-on for a multi-node ThoughtSpot cluster. 
 
-## Typical configuration for load balancers
+## Typical configuration for a load balancer
 
-1. Session affinity: Having it turned-on by default helps retain established SSL sessions; instead of having to frequently renegotiate sessions between the load balancer and back-end nodes. This is the recommended setting.
-2. Maximum size of HTTP POST request: Some load balancers / proxy solutions impose a default limit (as low as 1MB) on the size of HTTP POST requests. ThoughtSpot requires it to be set to 50 MB (or as close to it as possible) so please confirm you've set this correctly.
-3. Server-side SSL profile needs to be enabled on load balancers.
-4. The following SSL ciphers need to be enabled on server-side SSL profile : [Supported SSL ciphers]({{ site.baseurl}}/admin/setup/SSL-config.html#supported-ssl-ciphers)
+1. Session affinity: Having it enabled by default helps retain established SSL sessions, instead of having to frequently renegotiate sessions between the load balancer and back-end nodes. This is the recommended setting.
+2. Maximum size of HTTP POST request: Some load balancers / proxy solutions impose a default limit (as low as 1 MB) on the size of HTTP POST requests. ThoughtSpot requires it to be set to 50 MB (or as close to it as possible), so please confirm you've set this correctly.
+3. Server-side SSL profile must be enabled on load balancers.
+4. The following SSL ciphers must be enabled on server-side SSL profile : [Supported SSL ciphers]({{ site.baseurl}}/admin/setup/SSL-config.html#supported-ssl-ciphers)
 
 ## Web proxies
 
-You can access ThoughtSpot through any standard web proxy server. Web proxies are fairly universal regardless of the application they are proxying. 
-ThoughtSpot doesn't use any new protocols, like SPDY or HTTP/2, which may have a dependency on the proxy and as a result, ThoughtSpot is commonly placed behind a web HTTP/HTTPS proxy.
+You can access ThoughtSpot through any standard Web proxy server. Web proxies are fairly universal regardless of the application they are proxying. 
+ThoughtSpot doesn't use any new protocols, like SPDY or HTTP/2, which may have a dependency on the proxy and as a result, ThoughtSpot is commonly placed behind a Web HTTP/HTTPS proxy.
 
-The proxy can also round-robin across the nodes in ThoughtSpot cluster in which case you are using the web proxy as a load balancer. Your session will carry over if the proxy round robins between the ThoughtSpot backends as long as the URL doesn’t change.
+The proxy can also round-robin across the nodes in ThoughtSpot cluster in which case you are using the Web proxy as a load balancer. Your session will carry over, if the proxy round robins between the ThoughtSpot backends as long as the URL doesn’t change.
 
 ## Alternatives
-One way to load balance across all ThoughtSpot nodes in a cluster is to map one domain name (FQDN) to all the IPs in the cluster in a round robin fashion. 
-This is no longer recommended because:-
-1. This is not suitable for secured (https) based access.
-2. DNS based round-robin isn't aware of state of backend nodes and can still send requests to nodes no longer in service. 
+One way to load balance across all ThoughtSpot nodes in a cluster is to map one domain name (FQDN) to all the IPs in the cluster in a round-robin fashion. 
+This is no longer recommended because:
+1. This is not suitable for secured (HTTPS) access.
+2. DNS-based round-robin isn't aware of the state of back-end nodes and can still send requests to nodes that are no longer in service. 


### PR DESCRIPTION
This needs to be reviewed by Orion and Callosum teams before committing.

Changes
- Moved the DNS-based load balancing to the end and clearly stated we don't recommend it.
- Provided information necessary for third-party load balancers and how they work, along with use-cases.