### PR TITLE
updated current_version variable and topnav drop-down menus

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ locale                   : "en"
 destination              : ./_site
 output                   : web
 # Used to designate the current version. Edit when a new version is released
-current_version          : "5.2"
+current_version          : "5.3"
 # used for conditional content filtering
 description              : "Documentation for the ThoughtSpot BI product. ThoughtSpot is a business intelligence and big data analytics platform that helps you explore, analyze and share real-time business analytics data easily."
 twitter                  : thoughtspot

--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -14,7 +14,9 @@ topnav_dropdowns:
   sections:
     - title: Version
       sectionitems:
-        - title: latest (5.2)
+        - title: latest (5.3)
+          url: /5.3/index.html
+        - title: 5.2
           url: /5.2/index.html
         - title: 5.1
           url: /5.1/index.html


### PR DESCRIPTION
### What's changed:
- current version points to 5.3
- added 5.3 as latest and removed 3.5 and 4.2 from topnav drop-down menu

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>