### PR TITLE
5.2: updated current_version variable and topnav drop-down menus

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ locale                   : "en"
 destination              : ./_site
 output                   : web
 # Used to designate the current version. Edit when a new version is released
-current_version          : "5.2"
+current_version          : "5.3"
 # Note that site.baseurl for this site evaluates to:
 # http://docs.thoughtspot.com/<version>/
 # used for conditional content filtering

--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -14,8 +14,10 @@ topnav_dropdowns:
   sections:
     - title: Version
       sectionitems:
-        - title: latest (5.2)
-          url: /5.2/index.html
+        - title: latest (5.3)
+          url: /5.3/index.html
+        - title: 5.2
+          url: /5.2/index.html          
         - title: 5.1
           url: /5.1/index.html
         - title: 5.0
@@ -24,7 +26,3 @@ topnav_dropdowns:
           url: /4.5/index.html
         - title: 4.4
           url: /4.4/index.html
-        - title: 4.2
-          url: /4.2/4.2-home.html
-        - title: 3.5
-          url: /3.5/3.5-home.html


### PR DESCRIPTION
### What's changed:
- current version points to 5.3
- added 5.3 as latest and removed 3.5 and 4.2 from topnav drop-down menu

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>