### PR TITLE
5.3: fixed topnav drop-down to remove 3.5 and 4.2 releases

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -26,7 +26,3 @@ topnav_dropdowns:
           url: /4.5/index.html
         - title: 4.4
           url: /4.4/index.html
-        - title: 4.2
-          url: /4.2/4.2-home.html
-        - title: 3.5
-          url: /3.5/3.5-home.html


### PR DESCRIPTION
### What's changed:
- removed 3.5 and 4.2 from topnav drop-down menu


Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>