### PR TITLE
Enhance section "Next: Add Storage."

### DIFF
--- a/_appliance/aws/launch-an-instance.md
+++ b/_appliance/aws/launch-an-instance.md
@@ -95,3 +95,4 @@ See [Network policies]({{ site.baseurl }}/appliance/firewall-ports.html) for a c
 
 [EC2 Best Practices](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-best-practices.html)
 [Loading data from an AWS S3 bucket]({{site.baseurl }}/admin/loading/use-data-importer.html#loading-data-from-an-aws-s3-bucket)
+ 


### PR DESCRIPTION
The section "Next: Add Storage." needs to be enhanced as follows.

1. Add a screenshot of what attached volumes look like on AWS console (just like we've provided one for the screen about choosing AMIs).
2. The EBS volumes customer adds along with AMI should be set to not be terminated/deleted if the VM itself is deleted. This is to prevent potential loss of data and logs in case the VM is terminated accidentally.
3. The screenshot for EBS volumes should also make sure that shown attached EBS volumes are unticked (Set to not be deleted).

CC @rajeskr @mark-plummer