### PR TITLE
5.3: Removal of mgmt console info from release notes

### DIFF
--- a/_release/notes.md
+++ b/_release/notes.md
@@ -47,10 +47,6 @@ In this release, we introduce user Onboarding, which communicates the value of T
 
 - See the general overview of [How onboarding works for the user]({{ site.baseurl }}/end-user/onboarding/user-onboarding-experience.html).  
 
-### Management console
-
-**The Management Console is now available in beta.** Using the Management Console that is part of the ThoughtSpot Admin page, the administrators can manage, configure, monitor, and upgrade clusters. To enable this feature, contact ThoughtSpot Support. For more information, see [About Management Console]({{ site.baseurl }}/admin/setup/intro.html#about-management-console).
-
 ### ThoughtSpot mobile
 
 Our brand new mobile app is now available for customers with ThoughtSpot 5.1 or later. For more information about what you can do with it, see [mobile app features]({{ site.baseurl }}/admin/mobile/use-mobile.html#). For more information about how to deploy it, see [deploy mobile app]({{ site.baseurl }}/admin/mobile/deploy-mobile.html#).


### PR DESCRIPTION
### What's changed:
**Note**: Per Vishal Swarankar, Management Console did not ship with 5.3, as planned. 

As a result:
- Removing mgmt console from release notes

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>