### PR TITLE
5.3: Removal of `unique_count` from SpotIQ comparative analysis content

### DIFF
--- a/_release/notes.md
+++ b/_release/notes.md
@@ -81,7 +81,6 @@ We added a new chart that shows price movements of financial instruments. You ca
 
 SpotIQ Analysis now supports more complex measurements:  
 * _Sum over sum_ and _Average_ use 'what-if' percentage insights.  
-* _Unique count_  uses a 'versus' analysis to highlight absolute change grouped by different drill attributes  
 
 See [Comparative Analysis]({{ site.baseurl }}/spotiq/spotiq-comparative-analysis.html).
 

--- a/_spotiq/spotiq-comparative-analysis.md
+++ b/_spotiq/spotiq-comparative-analysis.md
@@ -13,7 +13,7 @@ With SpotIQ competitive analysis, you can compare two data points for simple or 
   * _Count_
   * _Sum over sum_, which generate a pinboard that has 'what-if' percentage insights
   * _Average_, which generate a pinboard that has 'what-if' percentage insights
-  * Other functions, such as _unique count_ , which use a 'versus' analysis to show the absolute change grouped by different drill attributes
+  * Other functions which use a 'versus' analysis to show the absolute change grouped by different drill attributes
 
 ## Basic Comparative Analysis in SpotIQ ##
 


### PR DESCRIPTION
### What's changed:

**Note**: Per Divy, "Comparative analysis for UNIQUE COUNT measures was turned off at the last moment as it required more rigorous testing." It did not ship in the 5.3 release. It will, instead, ship in the 5.3.1 release. 

As a result:
- Removed `unique_count` from SpotIQ Comparative Analysis content in release notes and SpotIQ section of doc.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>