### PR TITLE
Update LDAP-config-AD.md

### DIFF
--- a/_admin/setup/LDAP-config-AD.md
+++ b/_admin/setup/LDAP-config-AD.md
@@ -11,13 +11,14 @@ ThoughtSpot enables you to set up integration with Active Directory using LDAP. 
 
 ## Before you begin
 Before you configure ThoughtSpot for Active Directory, collect the following information:
-- **URL**: This is needed to connect to Active Directory. For example, `ldap://ad.yourdomain.local:389` or `ldap://ad.yourdomain.local:636`
-- **Domain name**: Default domain under which users who want to be authenticated against Active Directory reside. When a user logs in with a username, the default domain is added to the username before sending it to the LDAP server. If users reside in multiple domains, you can still designate one of them as the default. **_NOTE:_** Users belonging to a non-default domain will have to explicitly qualify their username when they log in, for example: `username@ad.yourdomain.local`
-- **Search base**: LDAP search base (Scope of searching for user/information within AD).
-- **Automatically add LDAP or AD users in ThoughtSpot? (yes/no)**: If you choose 'yes', new users in ThoughtSpot will be automatically created when authenticated against AD. Note that ThoughtSpot doesn't cache passwords for AD-authenticated users. If you choose 'no', users have to be manually created with a dummy password as a placeholder in ThoughtSpot before they can log in. The username you specify when creating the LDAP authenticated user manually in ThoughtSpot has to be domain qualified, for example: `username1@ad.yourdomain.local`. **_NOTE:_** In order to log in to ThoughtSpot, the user has to exist in ThoughtSpot independent of whether that user is authenticated against AD or against ThoughtSpot's internal authentication.
+- **URL**: Required to connect to Active Directory. For example, `ldap://ad.yourdomain.local:389` or `ldap://ad.yourdomain.local:636`
+- **Domain name**: Default domain under which users who want to be authenticated against Active Directory reside. When a user logs in with a username, the default domain is added to the username before sending it to the LDAP server. If users reside in multiple sub-domains, you can still designate one of them as the default. Authentication against multiple domains is not supported. **_NOTE:_** Users who don't belong to the default domain will have to explicitly qualify their username when they log in, for example: `username@ad.yourdomain.local`
+- **Search base**: LDAP search base (Scope of searching user information like email and displayName within AD).
+- **SSL**: If you want to use SSL, you must obtain the SSL certificate from an issuing authority. **_NOTE:_** If AD servers are behind a load balancer, you must procure the SSL certificate to identify ThoughtSpot to the load balancer (The communication after the load balancer is non-secure). ThoughtSpot does not support a scenario where multiple AD servers provide their own SSL certificates.
+- **Automatically add LDAP or AD users in ThoughtSpot? (yes/no)**: If you choose 'yes', new users are automatically created within ThoughtSpot when successfully authenticated against AD. Note that ThoughtSpot doesn't cache passwords for AD-authenticated users. If you choose 'no', users have to be manually created with a dummy password as a placeholder in ThoughtSpot before they can log in. The username you specify when creating the LDAP authenticated user manually in ThoughtSpot has to be domain qualified, for example: `username1@ad.yourdomain.local`. **_NOTE:_** In order to log in to ThoughtSpot, the user has to exist in ThoughtSpot independent of whether that user is authenticated against AD or against ThoughtSpot's internal authentication.
 - **Also use ThoughtSpot internal authentication? (yes/no)**: If you choose 'yes', ThoughtSpot will first attempt to authenticate the user against AD. If that attempt fails, it will then attempt to authenticate the user as an internal/local ThoughtSpot user. If either of these succeed, then the user is successfully logged in. This is useful in scenarios where some users are not in AD and are created only in ThoughtSpot.
 
-## Configure using Management Console
+<!-- ## Configure using Management Console
 
 {% include note.html content="The Management Console is now available in beta for customers with ThoughtSpot 5.3 or newer." %}
 
@@ -74,8 +75,8 @@ To configure authentication via Active Directory:
    </tr>
    </table>
 
-6. Click **Save** to configure the active directory configuration.
-
+6. Click **Save** to configure the active directory configuration. 
+-->
 ## Configure using tscli
 
 You do not have to create a user called `tsadmin` on your LDAP server. Internal authentication can be used for `tsadmin`. To configure AD based authentication:

--- a/_admin/setup/LDAP-config-AD.md
+++ b/_admin/setup/LDAP-config-AD.md
@@ -6,32 +6,22 @@ last_updated: tbd
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-ThoughtSpot enables you to set up integration with LDAP using Active Directory. After successful setup, you can authenticate users against secure LDAP.
+ThoughtSpot enables you to set up integration with Active Directory using LDAP. After successful setup, you can authenticate users against AD, including authentication over SSL.
 
 
 ## Before you begin
-Before you configure LDAP for Active Directory, collect the following information:
-- **URL**: This is needed to connect to Active Directory. For example, `ldap://192.168.2.48:389`
-- **Domain name**: Preferred domain under which users who want to be authenticated against Active Directory reside. When a user logs in with a username, the default domain is added to the username before sending it to the LDAP server. If users reside in multiple domains, you can still designate one of them as the default.
-
-  **_NOTE:_** Users belonging to a non-default domain will have to explicitly qualify their username when they log in, for example: `username@ldap1.thoughtspot.com`
-- **Search base**: LDAP search base that allows ThoughtSpot to find user properties such as email and display name from LDAP.
-- **SSL**: Obtain the SSL certificate from an issuing authority if you want to use SSL.
-- **Automatically add LDAP or AD users in ThoughtSpot? (yes/no)**: If you choose 'yes', the user that does not exist in ThoughtSpot is automatically created and authenticated against LDAP. Note that such users passwords exist only in LDAP and are not stored in ThoughtSpot.
-
-  If you choose 'no', users have to be manually created with a dummy password as a placeholder in ThoughtSpot before they can log in. The username you specify when creating the LDAP authenticated user manually in ThoughtSpot has to be domain qualified, for example: `username@ldap1.thoughtspot.com`.
-
-  **_NOTE:_** In order to log in to ThoughtSpot, the user has to exist in ThoughtSpot independent of whether that user is authenticated against LDAP or against ThoughtSpot's internal authentication.
-- **Also use ThoughtSpot internal authentication? (yes/no)**: If you choose 'yes', ThoughtSpot will first attempt to authenticate the user against LDAP when a user logs in. If that attempt fails, it will then attempt to authenticate the user against ThoughtSpot. If either of these succeed, then the user is successfully logged in.
-
-  **_NOTE:_** You can use this option only in `tscli`. This is useful in scenarios where some users are not in LDAP and are created only in ThoughtSpot.
-
+Before you configure ThoughtSpot for Active Directory, collect the following information:
+- **URL**: This is needed to connect to Active Directory. For example, `ldap://ad.yourdomain.local:389` or `ldap://ad.yourdomain.local:636`
+- **Domain name**: Default domain under which users who want to be authenticated against Active Directory reside. When a user logs in with a username, the default domain is added to the username before sending it to the LDAP server. If users reside in multiple domains, you can still designate one of them as the default. **_NOTE:_** Users belonging to a non-default domain will have to explicitly qualify their username when they log in, for example: `username@ad.yourdomain.local`
+- **Search base**: LDAP search base (Scope of searching for user/information within AD).
+- **Automatically add LDAP or AD users in ThoughtSpot? (yes/no)**: If you choose 'yes', new users in ThoughtSpot will be automatically created when authenticated against AD. Note that ThoughtSpot doesn't cache passwords for AD-authenticated users. If you choose 'no', users have to be manually created with a dummy password as a placeholder in ThoughtSpot before they can log in. The username you specify when creating the LDAP authenticated user manually in ThoughtSpot has to be domain qualified, for example: `username1@ad.yourdomain.local`. **_NOTE:_** In order to log in to ThoughtSpot, the user has to exist in ThoughtSpot independent of whether that user is authenticated against AD or against ThoughtSpot's internal authentication.
+- **Also use ThoughtSpot internal authentication? (yes/no)**: If you choose 'yes', ThoughtSpot will first attempt to authenticate the user against AD. If that attempt fails, it will then attempt to authenticate the user as an internal/local ThoughtSpot user. If either of these succeed, then the user is successfully logged in. This is useful in scenarios where some users are not in AD and are created only in ThoughtSpot.
 
 ## Configure using Management Console
 
-{% include note.html content="The Management Console is now available in beta for customers with ThoughtSpot 5.3 or later. Please contact ThoughtSpot Support, if you want to try it." %}
+{% include note.html content="The Management Console is now available in beta for customers with ThoughtSpot 5.3 or newer." %}
 
-To configure LDAP for active directory:
+To configure authentication via Active Directory:
 
 1. Log into ThoughtSpot from a browser.
 2. Click the **Admin** menu on the top navigation bar.
@@ -86,14 +76,12 @@ To configure LDAP for active directory:
 
 6. Click **Save** to configure the active directory configuration.
 
-
-
 ## Configure using tscli
 
-You do not have to create a user called `tsadmin` on your LDAP server. Internal authentication can be used for `tsadmin`. To configure LDAP:
+You do not have to create a user called `tsadmin` on your LDAP server. Internal authentication can be used for `tsadmin`. To configure AD based authentication:
 
 1. Log in to the Linux shell using SSH.
-2. Run the command to configure LDAP:
+2. Run the command to configure AD authentication:
 
     ```
     $ tscli ldap configure
@@ -105,24 +93,17 @@ You do not have to create a user called `tsadmin` on your LDAP server. Internal 
     Choose the LDAP protocol:
     [1] Active Directory
     Option number: 1
-
     Configuring Active Directory
-
-    URL to connect to Active Directory. (Example: ldap://192.168.2.100:389): ldap://192.168.2.100:389
-
-    Default domain (Example: ldap.thoughtspot.com): ldap.thoughtspot.com
-
+    URL to connect to Active Directory. (Example: ldap://ad.yourdomain.local:389): ldaps://ad.yourdomain.local:636
+    Default domain (Example: ldap.thoughtspot.com): yourdomain.local
     Use SSL (LDAPS) (y/n): n
-
-    LDAP search base (Example: cn=Users): cn=Users
-
+    LDAP search base (Example: cn=Users): cn=Users,ou=orgunit,dc=youdomain,dc=local
     Automatically add LDAP users in ThoughtSpot (y/n): y
-
     Also use ThoughtSpot internal authentication (y/n): y
     ```
 
-4. If you are using SSL, [add the SSL certificate for LDAP](add-SSL-for-LDAP.html#).
-5. If you want to remove the LDAP configuration, issue:
+4. If you are using SSL, [add the SSL certificate for AD](add-SSL-for-LDAP.html#).
+5. If you want to remove the AD configuration, issue:
 
     ```
     $ tscli ldap purge-configuration


### PR DESCRIPTION
Hey @mark-plummer 

1. We do not need the customer to obtain the AD SSL certificate from a third party or external authority. If customer has AD setup for SSL, it will already have its own SSL certificate installed and ThoughtSpot SREs can fetch/use that certificate using `openssl s_client -connect ad.yourdomain.local:636 > AD_SSL_certificicate.pem` and set it up in TS.
2. We don't support LDAP servers but only AD (Active directory). So replacing repeated references to LDAP by AD/Active Directory.
3. Provided meaningful example compliant with best practices (use domain name and not IP addresses).
4. Modified "4. If you are using SSL, [add the SSL certificate for LDAP](add-SSL-for-LDAP.html#)" to "4. If you are using SSL, [add the SSL certificate for AD]". Also, need to change "(add-SSL-for-LDAP.html#)" to "(add-SSL-for-AD.html#)"
5. Removed the reference asking the customer to contact support for using beta functionality "The Management Console". The idea behind the management console is to enable the customer to self-serve and we don't want to encourage customers to call up TS SRE team without even trying the console.

Please get this reviewed by Callosum team before merging.
Get in touch with me if any clarifications are needed.