### PR TITLE
Added examples. Updated doc for Azure compliance

### DIFF
--- a/_admin/setup/NAS-mount.md
+++ b/_admin/setup/NAS-mount.md
@@ -96,30 +96,22 @@ To mount a NAS file system using the admin UI:
 To mount a NAS file system using the tscli:
 1. Log in to the Linux shell using SSH.
 2. Mount the directory to the file system, by issuing the appropriate command:
-    -   For an NFS (Network File System) directory:
+    -   Example for an NFS (Network File System) directory:
 
         ```
-        tscli nas mount-nfs
-           --server <server_NFS_address>
-           --path_on_server <path>
-           --mount_point <target>
-           --options vers=<version>, sec=<security scheme>, <OPTIONS>
+        tscli nas mount-nfs --server storageservername.file.yourdomain.net
+           --path_on_server <path>  /tsdev-backup --mount_point /export/BACKUPS/
+           --options vers=<version>,sec=<security scheme>,<OPTIONS>
         ```
 
         {% include note.html content="Other command-line options are available to forward to the command (default: `noexec`)." %}
 
-    -   For a CIFS (Common Internet File System) directory:
+    -   Example for a CIFS (Common Internet File System) directory:
 
         ```
-        tscli nas mount-cifs
-           --server <server_CIFS_address>
-           --path_on_server <path>
-           --mount_point <target>
-           --username <user>
-           --password <password>
-           --uid <uid>
-           --gid <gid>
-           --options <OPTIONS>
+        tscli nas mount-cifs --server storageservername.file.yourdomain.net
+          --path_on_server /tsdev-backup --mount_point /export/BACKUPS/
+          --username 'avtprdweutspotdev' --uid 1001 --gid 1001 --options 'vers=3.0'
         ```
 
         {% include note.html content="Other command-line options are available to forward to the `mount.cifs` command (default: `noexec`)." %}


### PR DESCRIPTION
1. Provided real-life examples for both CIFS and NFS mounts (Example includes Azure specific options)
2. NFS mount command had extra spaces. Removed. These would lead to errors in the field.

Should retrospectively fix 5.2 docs as well.