### PR TITLE
5.3: Changed Config AD page title

### DIFF
--- a/_admin/setup/LDAP-config-AD.md
+++ b/_admin/setup/LDAP-config-AD.md
@@ -1,5 +1,5 @@
 ---
-title: [Configure LDAP for Active Directory]
+title: [Configure authentication through Active Directory]
 tags: [SAML_LDAP_AD, tscli]
 keywords: LDAP, "Active Directory"
 last_updated: tbd
@@ -7,7 +7,6 @@ sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
 ThoughtSpot enables you to set up integration with Active Directory using LDAP. After successful setup, you can authenticate users against AD, including authentication over SSL.
-
 
 ## Before you begin
 Before you configure ThoughtSpot for Active Directory, collect the following information:
@@ -88,7 +87,7 @@ To configure LDAP for active directory:
    </tr>
    </table>
 
-6. Click **Save** to configure the active directory configuration. 
+6. Click **Save** to configure the active directory configuration.
 
 -->
 ## Configure using tscli

--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -496,7 +496,7 @@ entries:
         - title: About LDAP integration
           url: /admin/setup/about-LDAP.html
           output: web,admBk
-        - title: Configure LDAP for Active Directory
+        - title: Configure authentication through Active Directory
           url: /admin/setup/LDAP-config-AD.html
           output: web,admBk
         - title: Add the SSL certificate for LDAP

--- a/_release/notes.md
+++ b/_release/notes.md
@@ -55,7 +55,7 @@ Our brand new mobile app is now available for customers with ThoughtSpot 5.1 or 
 
 To upgrade to this release, all users must have a valid email in ThoughtSpot. We block the upgrade if all users don't have valid emails.
 
-Before this release, the email field was not mandatory. See changes to [Create a user through the interface]({{ site.baseurl }}/admin/users-groups/add-user.html#create-a-user-through-the-interface). To make bulk updates to emails, see [Configure LDAP for Active Directory]({{ site.baseurl }}/admin/setup/LDAP-config-AD.html).
+Before this release, the email field was not mandatory. See changes to [Create a user through the interface]({{ site.baseurl }}/admin/users-groups/add-user.html#create-a-user-through-the-interface). To make bulk updates to emails, see [Configure authentication through Active Directory]({{ site.baseurl }}/admin/setup/LDAP-config-AD.html).
 
 ### Amazon S3 persistent storage option
 


### PR DESCRIPTION
### What's changed:
- Changed title of "Configure LDAP for Active Directory" to "Configure authentication through Active Directory" per guidance from Rohit in PR: #1244.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>