### PR TITLE
Update to "Encryption of data in transit page within a cluster" page

### DIFF
--- a/_admin/data-security/encryption-of-data.md
+++ b/_admin/data-security/encryption-of-data.md
@@ -50,3 +50,4 @@ Note: IPSec is supported in ThoughtSpot software versions starting from 4.5.1.4
 The following ports must be open between nodes to allow IPSec encryption:
   - UDP port 500 (for IKE)
   - UDP port 4500 (for IPSec over IDP)
+  - IP Protocol 50 (ESP)


### PR DESCRIPTION
### What's changed:
- Added 'IP Protocol 50 (ESP)  to firewall config list on 'Encryption of data in transit within a cluster' page (per request from Sameer).

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>