### PR TITLE
Update to "Encryption of data in transit page within a cluster" page

### DIFF
--- a/_admin/data-security/encryption-of-data.md
+++ b/_admin/data-security/encryption-of-data.md
@@ -50,3 +50,4 @@ Note: IPSec is supported in ThoughtSpot software versions starting from 4.5.1.4
 The following ports must be open between nodes to allow IPSec encryption:
   - UDP port 500 (for IKE)
   - UDP port 4500 (for IPSec over IDP)
+  - IP Protocol 50 (ESP)

--- a/_admin/mobile/deploy-mobile.md
+++ b/_admin/mobile/deploy-mobile.md
@@ -5,7 +5,7 @@ last_updated: tbd
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-Deploying the ThoughSpot mobile app to your users allows them to access their data and make decisions remotely from their Apple iOS device. For more information about features in the mobile app, refer to [ThoughtSpot mobile overview]({{ site.baseurl }}/admin/mobile/use-mobile.html#).
+Deploying the ThoughtSpot mobile app to your users allows them to access their data and make decisions remotely from their Apple iOS device. For more information about features in the mobile app, refer to [ThoughtSpot mobile overview]({{ site.baseurl }}/admin/mobile/use-mobile.html#).
 
 ## Deployment options
 

--- a/_admin/mobile/use-mobile.md
+++ b/_admin/mobile/use-mobile.md
@@ -5,7 +5,7 @@ last_updated: tbd
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-ThoughSpot mobile app version 1.1 allows you to discover insights in seconds from billions of rows of data, right from the palm of your hand. You can access your ThoughtSpot cluster to search answers and pinboards. You can also create pinboards using existing answers and use pinboard filters.
+ThoughtSpot mobile app version 1.1 allows you to discover insights in seconds from billions of rows of data, right from the palm of your hand. You can access your ThoughtSpot cluster to search answers and pinboards. You can also create pinboards using existing answers and use pinboard filters.
 
 ## Requirements
 

--- a/_app-integrate/embedding-viz/embed-a-viz.md
+++ b/_app-integrate/embedding-viz/embed-a-viz.md
@@ -60,7 +60,7 @@ embed a ThoughtSpot pinboard or visualization. For this example, you can get a c
     Here are the fields in the `test.html` file you need to edit.
 
     ```JavaScript
-    var protocol = "THOUGHSPOT_PROTOCOL";
+    var protocol = "THOUGHTSPOT_PROTOCOL";
     var hostPort = "HOST_PORT";   
 
     var pinboardId = "PINBOARD_ID";

--- a/_appliance/aws/ha-aws-efs.md
+++ b/_appliance/aws/ha-aws-efs.md
@@ -7,7 +7,7 @@ permalink: /:collection/:path.html
 ---
 ## Setting up High Availability (HA) for your ThoughtSpot cluster using AWS Elastic File System (EFS)
 
-To set up HA for your ThoughSpot cluster, do the following:
+To set up HA for your ThoughtSpot cluster, do the following:
 
 1. Create an EFS File System that spanns across different availability zones, and across different subnets.
 

--- a/_end-user/introduction/about-user.md
+++ b/_end-user/introduction/about-user.md
@@ -38,7 +38,7 @@ Select **Email me sharing notifications** to receive emails whenever another use
 
 When you are relatively new to using ThoughtSpot, we help you to become productive faster.
 
-Whenever you need a refresh, navigate to **My Profile*. Under **Preferences**, see the **New user onboarding** option. Click **Revisit**, and ThoughSpot guides you through onboarding again.
+Whenever you need a refresh, navigate to **My Profile*. Under **Preferences**, see the **New user onboarding** option. Click **Revisit**, and ThoughtSpot guides you through onboarding again.
 
 ![]({{ site.baseurl }}/images/onboarding-revisit.png "Revisit onboarding")
 

--- a/downloads/test.html
+++ b/downloads/test.html
@@ -35,7 +35,7 @@
 //// <protocol>:<host>:<port>/#/embed/viz/<pinboardID>/<vizualizationId> //////
 ///////////////////////////////////////////////////////////////////////////////
 
-  var protocol = "THOUGHSPOT_PROTOCOL"; // The protocol that appears in the pinboard/visualization link
+  var protocol = "THOUGHTSPOT_PROTOCOL"; // The protocol that appears in the pinboard/visualization link
   var hostPort = "HOST_PORT";   // Hostport info for ThoughtSpot app. Ex: <host>:<port> or <host>
 
   // Use Actions > Copy link from a pinboard or a visualization in a pinboard to get a link for embedding


### PR DESCRIPTION
What's changed:
- Added 'IP Protocol 50 (ESP) to firewall config list on 'Encryption of data in transit within a cluster' page (per request from Sameer).
- Fixed misspellings of ThoughtSpot.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>