### PR TITLE
Fix "Embedding case + VMware download URLs"

### DIFF
--- a/_release/downloads.md
+++ b/_release/downloads.md
@@ -28,11 +28,8 @@ See [Install the ODBC driver on Linux]({{ site.baseurl }}/data-integrate/clients
 ## JavaScript API ##
 For the JavaScript API, see the [JavaScript API library](https://thoughtspot.egnyte.com/dl/D8tbICaVbR/).
 
-## Embedding ThoughtSpot ##
-For information on ThoughtSpot Extended Enterprise Edition, our embeddable offering, see [**Embedding**]({{ site.baseurl }}/app-integrate/introduction/introduction.html).
 
-## Virtual Platforms ##
 
-* **VMware**<br>
-[ts-centos7-vmware-template.tar.gz](https://thoughtspot.egnyte.com/dl/iWvEqo76Pr)<br>
-[Set up VMware for ThoughtSpot]({{ site.baseurl }}/appliance/vmware/vmware-setup.html)
+
+
+


### PR DESCRIPTION
1. This page is for general purpose, platform independent downloads.
We need to delete the download URL for VMware from this page and need to add it to  section "https://docs.thoughtspot.com/5.3/appliance/vmware/vmware-setup.html#use-the-ovf-to-create-a-vm" on webpage https://docs.thoughtspot.com/5.3/appliance/vmware/vmware-setup.html instead.

## Virtual Platforms ##
* **VMware**<br>
[ts-centos7-vmware-template.tar.gz](https://thoughtspot.egnyte.com/dl/iWvEqo76Pr)<br>
[Set up VMware for ThoughtSpot]({{ site.baseurl }}/appliance/vmware/vmware-setup.html)

2. Information below doesn't belong on the download page. Needs to be removed.

## Embedding ThoughtSpot ##
For information on ThoughtSpot Extended Enterprise Edition, our embeddable offering, see [**Embedding**]({{ site.baseurl }}/app-integrate/introduction/introduction.html).