### PR TITLE
5.3.1 embrace  and release notes updates

### DIFF
--- a/_data-integrate/embrace/embrace-intro.md
+++ b/_data-integrate/embrace/embrace-intro.md
@@ -19,6 +19,7 @@ You create a connection to a Snowflake database, choosing the columns from each 
 - Centralize data management and governance in Snowflake.
 - Save significant time and money by avoiding ETL pipelines.
 - Set up and schedule sync of data into ThoughtSpot.
+- Connect to multiple Snowflake databases (starting in release 5.3.1).
 
 ## Embrace modes
 
@@ -52,5 +53,5 @@ Create the connection between ThoughtSpot and tables in a Snowflake database.
 Set your connection to copy tables from Snowflake into ThoughtSpot.
 -   **[Modify a connection]({{ site.baseurl }}/data-integrate/embrace/getting-started/modify-a-connection.html)**  
 Edit, remap or delete a connection to tables in a Snowflake database.
-- **[Know database connector details]({{ site.baseurl }}/data-integrate/embrace/reference/embrace-connection-credentials.html)**  
+- **[Connectors reference]({{ site.baseurl }}/data-integrate/embrace/reference/embrace-connection-credentials.html)**  
 Source cloud data connectors, and their connection credentials, supported by Embrace.

--- a/_data-integrate/embrace/embrace-sync.md
+++ b/_data-integrate/embrace/embrace-sync.md
@@ -74,6 +74,6 @@ To remove a schedule:
 
 ## Related information
 - [Modify a connection]({{ site.baseurl }}/data-integrate/embrace/getting-started/modify-a-connection.html)
-- [Know Embrace connector]({{ site.baseurl }}/data-integrate/embrace/reference/embrace-connection-credentials.html)
-- [Data sources management]({{ site.baseurl }}/admin/loading/loading-intro.html)
-- [Data security]({{ site.baseurl }}/admin/architecture/security.html)
+- [Connectors reference]({{ site.baseurl }}/data-integrate/embrace/reference/embrace-connection-credentials.html)
+- [Load and manage data]({{ site.baseurl }}/admin/loading/loading-intro.html)
+- [Data and object security]({{ site.baseurl }}/admin/architecture/security.html)

--- a/_data-integrate/embrace/getting-started/setup-a-new-connection.md
+++ b/_data-integrate/embrace/getting-started/setup-a-new-connection.md
@@ -41,6 +41,6 @@ Not all of ThoughtSpot's features are supported with linked tables. For details,
 
 ## Related information
 - [Modify a connection]({{ site.baseurl }}/data-integrate/embrace/getting-started/modify-a-connection.html)
-- [Know Embrace connector]({{ site.baseurl }}/data-integrate/embrace/reference/embrace-connection-credentials.html)
-- [Data sources management]({{ site.baseurl }}/admin/loading/loading-intro.html)
-- [Data security]({{ site.baseurl }}/admin/architecture/security.html)
+- [Connectors reference]({{ site.baseurl }}/data-integrate/embrace/reference/embrace-connection-credentials.html)
+- [Load and manage data]({{ site.baseurl }}/admin/loading/loading-intro.html)
+- [Data and object security]({{ site.baseurl }}/admin/architecture/security.html)

--- a/_data-integrate/embrace/reference/embrace-connection-credentials.md
+++ b/_data-integrate/embrace/reference/embrace-connection-credentials.md
@@ -24,5 +24,5 @@ Here is a list of all of the external database connectors, and their connection 
  - **Schema**: Optional. Specify the schema associated with the database.
 
 ## Related articles
--   [Set up a new connection]({{ site.baseurl }}/data-integrate/embrace/getting-started/setup-a-new-connection.html)
+-   [Add a connection]({{ site.baseurl }}/data-integrate/embrace/getting-started/setup-a-new-connection.html)
 -   [Modify a connection]({{ site.baseurl }}/data-integrate/embrace/getting-started/modify-a-connection.html)

--- a/_release/notes.md
+++ b/_release/notes.md
@@ -58,23 +58,25 @@ You can now load data from an S3 bucket into your ThoughtSpot AWS instance faste
 {: id="531-fixed"}
 ## 5.3.1 Fixed Issues
 
-An issue when using a custom calendar where a query that filters on a date field causes a database error is now fixed.
+The following issues are fixed in the 5.3.1 release:
 
-A problem where signing in to ThoughtSpot multiple times in quick succession causes a 500 error is now fixed.
+- Using a custom calendar, and doing a query that filters on a date field causes a database error.
 
-An issue when row-level security is used, where a 2-column join in a fan-trap query does not work if the column contains NULL data/values is now fixed.
+- Signing in to ThoughtSpot multiple times in quick succession causes a 500 error.
 
-A problem where opening certain pinboards can cause the Google Chrome browser to freeze is now fixed.
+- When row-level security is used, a 2-column join in a fan-trap query does not work if the column contains NULL data/values.
 
-An issue where columns renamed in a worksheet revert back to their original names later is now fixed.
+- Opening certain pinboards can cause the Google Chrome browser to freeze.
 
-A problem where columns cannot be deleted from a worksheet is now fixed.
+- Columns renamed in a worksheet revert back to their original names later.
 
-An issue in custom calendar where filtering the date values by year, month or quarter does not work is now fixed.
+- Columns cannot be deleted from a worksheet.
 
-A problem where Canadian postal codes do not appear on maps is now fixed.
+- Using a custom calendar and filtering date values by year, month or quarter does not work.
 
-An issue where the Admin > Style Customization page indicates the wrong pixel dimensions required for a wide application logo is now fixed.
+- Canadian postal codes do not appear on maps.
+
+- The Admin > Style Customization page indicates the wrong pixel dimensions required for a wide application logo.
 
 {: id="53-new"}
 ## 5.3 New Features and Functionality

--- a/_release/notes.md
+++ b/_release/notes.md
@@ -38,7 +38,7 @@ First, upgrade to version 5.1.x, version 5.2.x, or version 5.3, and then to the 
 ## 5.3.1 New Features and Functionality
 
 ### Onboarding
-In this release, administrators can configure 'Welcome' emails to send to both new and existing users, and to existing groups. See [Edit a group]({{ site.baseurl }}/admin/users-groups/add-group.html#edit-a-group) and
+In this release, administrators can configure 'Welcome' emails to send to both new and existing users, and to existing groups. See [Edit a group]({{ site.baseurl }}/admin/users-groups/add-group.html#edit-group) and
 [Create a user]({{ site.baseurl }}/admin/users-groups/add-user.html#create-a-user-through-the-interface).
 
 ### Embrace


### PR DESCRIPTION
### What's changed:
- Fixed link naming on some Embrace pages to match header of page linked to.
- Corrected link to edit a group page from onboarding section of 5.3.1 release notes.
- Reformatted fixed issues in 5.3.1 release notes with new heading and streamlined/bulleted listing.