### PR TITLE
5.3: Update to Set up the ODBC Driver for SSIS

### DIFF
--- a/_data-integrate/clients/set-up-the-odbc-driver-using-ssis.md
+++ b/_data-integrate/clients/set-up-the-odbc-driver-using-ssis.md
@@ -102,11 +102,7 @@ ThoughtSpot and bring the table in.
 
 4.  In the Client Configuration Dialog, enter the **Server IP** and **Server Port**.
 
-      Any node IP that has Simba server running on it should work. You can
-      specify multiple secondary servers and ThoughtSpot will resolve to the
-      server Simba is running on. To provide  **Secondary Servers** dialog enter
-      one server IP per line. The line return serves as a separator, comma
-      separation is not supported.
+      Enter any node IP that has Simba server running on it. In **Secondary Servers**, you must specify all node IPs, because ThoughtSpot must resolve to the server Simba runs on, and that server can change after an upgrade. Enter one server IP per line. The line return serves as a separator. Comma separated values are not supported.
 
 5. Click **OK** twice to close the Client Configuration Dialog and the ODBC Data Source Administrator.
 


### PR DESCRIPTION
### What's changed:
- Updated note in Set up the ODBC Driver for SSIS page to include that secondary servers must list all of IP nodes,  so that TS can resolve to the one running Simba server. The reason for this is because after an upgrade it appears the node where Simba server is running may change.
Page updated: https://docs.thoughtspot.com/5.3/data-integrate/clients/set-up-the-odbc-driver-using-ssis.html#configure-the-odbc-data-source-administrator (Will publish after 5.3.1 GA)
