### PR TITLE
5.3: 3rd party software fix

### DIFF
--- a/_admin/data-security/about-secure-monitor-sw.md
+++ b/_admin/data-security/about-secure-monitor-sw.md
@@ -1,18 +1,16 @@
 ---
-title: [About third party security and monitoring software]
-
-
-summary: "You can install third party software for security, governance, and monitoring of ThoughtSpot."
+title: [About third-party security and monitoring software]
+summary: "You can install third-party software for security, governance, and monitoring of ThoughtSpot."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-In addition to the ThoughtSpot monitoring and security features, some companies require specific additional third party software to comply with their internal IT policies. This allows them to support all of their systems with a common set of security and management tools.
+In addition to the ThoughtSpot monitoring and security features, some companies require specific additional third-party software to comply with their internal IT policies. This allows them to support all of their systems with a common set of security and management tools.
 
-For example, you may wish to accomplish some security and monitoring tasks with your own third party software. These tasks include things like pushing alerts, events, forensics, audit trails, insights, etc. from ThoughtSpot to your own local monitoring systems.
+For example, you may wish to accomplish some security and monitoring tasks with your own third-party software. These tasks include things like pushing alerts, events, forensics, audit trails, insights, etc. from ThoughtSpot to your own local monitoring systems.
 
-## Supported third party software
+## Supported third-party software
 
-ThoughtSpot supports installation of the following third party software on the ThoughtSpot instance:
+ThoughtSpot supports installation of the following third-party software on the ThoughtSpot instance:
 
 - Qualys
   Qualys is a widely used technical vulnerabilities and security compliance scanning tool. For more information about Qualys, see the [Qualys documentation](http://www.qualys.com/documentation/).
@@ -23,9 +21,13 @@ ThoughtSpot supports installation of the following third party software on the T
 - Splunk
   You can install Splunk rsyslog and use it to forward ThoughtSpot logs to Splunk. For more information about Splunk, see the [Splunk documentation](http://docs.splunk.com/).
 
+### Install third-party software
+
+For details on how to install third-party software, see: [Installing third-party security and monitoring software]({{ site.baseurl}}/admin/data-security/install-secure-monitor-sw.html#)   
+
 ## What is not supported
 
-When installing and configuring third party software on a ThoughtSpot cluster, follow the following guidelines to avoid interfering with cluster operations:
+When installing and configuring third-party software on a ThoughtSpot cluster, follow the following guidelines to avoid interfering with cluster operations:
 
 - Avoid making any direct changes to any files outside of the /home directory.
 - Do not remove existing SSH keys or authorized keys from /home/admin/.ssh
@@ -43,7 +45,7 @@ Qualys is supported for scanning of ThoughtSpot clusters for security vulnerabil
 
 ## SNMP Traps
 
-ThoughtSpot has a built-in alerting service that can also be used to send SNMP traps. Many third party monitoring systems share the common standard of using SNMP traps, and you can take advantage of those capabilities with ThoughtSpot.
+ThoughtSpot has a built-in alerting service that can also be used to send SNMP traps. Many third-party monitoring systems share the common standard of using SNMP traps, and you can take advantage of those capabilities with ThoughtSpot.
 
 ThoughtSpot supports SNMP for read only. So for example, you can read the IP address of the cluster, but not change it using SNMP.
 
@@ -58,7 +60,3 @@ Here are some links to help you learn where various logs are written in ThoughtS
 - [Monitoring logs]({{ site.baseurl}}/admin/system-monitor/introduction.html#)
 - [Audit logs]({{ site.baseurl}}/admin/data-security/audit-logs.html#)
 - [Alert code reference]({{ site.baseurl}}/reference/alerts-reference.html#)
-
-## Related Topics
-
-- [Installing third party security and monitoring software]({{ site.baseurl}}/admin/data-security/install-secure-monitor-sw.html#)

--- a/_admin/data-security/audit-logs.md
+++ b/_admin/data-security/audit-logs.md
@@ -1,7 +1,5 @@
 ---
-title: [System security]
-
-
+title: [System security tools and processes]
 summary: "System security refers to audit logs and security policies."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
@@ -75,6 +73,6 @@ The ThoughtSpot Engineering and ThoughtSpot Support teams are notified of Common
 
 Whenever a CVE is identified, and an OS package needs to be updated, the next patch release will include the patch or update. You can view installed Linux packages at any time, along with the version numbers of the installed packages.
 
-## Third party security software for security, governance, and monitoring of ThoughtSpot
+## Third-party security software for security, governance, and monitoring of ThoughtSpot
 
-You can install supported [third party security and monitoring software]({{ site.baseurl}}/admin/data-security/about-secure-monitor-sw.html#) on a ThoughtSpot cluster.
+You can install supported [third-party security and monitoring software]({{ site.baseurl}}/admin/data-security/about-secure-monitor-sw.html#) on a ThoughtSpot cluster.

--- a/_admin/data-security/install-secure-monitor-sw.md
+++ b/_admin/data-security/install-secure-monitor-sw.md
@@ -1,14 +1,12 @@
 ---
-title: [Installing third party security and monitoring software]
-
-
-summary: "You can install third party software for security, governance, and monitoring of ThoughtSpot."
+title: [Installing third-party security and monitoring software]
+summary: "You can install third-party software for security, governance, and monitoring of ThoughtSpot."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-This procedure shows how to install supported [third party security and monitoring software]({{ site.baseurl}}/admin/data-security/about-secure-monitor-sw.html#) on a ThoughtSpot cluster:
+This procedure shows how to install supported [third-party security and monitoring software]({{ site.baseurl}}/admin/data-security/about-secure-monitor-sw.html#) on a ThoughtSpot cluster:
 
-## To install third party software
+## To install third-party software
 
 1. Log in to the Linux shell using SSH.
 

--- a/_admin/manage-jobs/about-scheduled-pinboards.md
+++ b/_admin/manage-jobs/about-scheduled-pinboards.md
@@ -1,6 +1,5 @@
 ---
 title: ["Job management (scheduled pinboards)"]
-
 last_updated: tbd
 summary: "All jobs on your cluster will appear on the Jobs Management page. You can also view jobs for individual pinboards under the pinboard Actions dropdown."
 sidebar: mydoc_sidebar

--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -634,9 +634,18 @@ entries:
       - title: Overview of security features
         url: /admin/data-security/about-security.html
         output: web,admBk
-      - title: System Security
-        url: /admin/data-security/audit-logs.html
+      - levelThreeTitle: System security
         output: web,admBk
+        levelThreeItems:
+        - title: Tools and processes
+          url: /admin/data-security/audit-logs.html
+          output: web,admBk
+        - title: About third-party software
+          url: /admin/data-security/about-secure-monitor-sw.html
+          output: web,admBk
+        - title: Installing third-party software
+          url: /admin/data-security/install-secure-monitor-sw.html
+          output: web,admBk
       - levelThreeTitle: Data security
         output: web,admBk
         levelThreeItems:


### PR DESCRIPTION
### What's changed:
• Linked the **About third-party** and **Installing third-party software** pages to the doc site sidebar
• In the _Supported third-party software_ section of **About third-party sw** page, added xref to **Installing third-party sw** page.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>