### PR TITLE
5.2: SSL required ports update updates to correct missing ports for ssl config

### DIFF
--- a/_admin/setup/SSL-config.md
+++ b/_admin/setup/SSL-config.md
@@ -22,6 +22,12 @@ There are many SSL vendors to choose from. Check with your existing Web hosting 
 
 When you apply for the SSL certificate, you may specify a SAN, wildcard, or single domain certificate. Any of these can work with ThoughtSpot.
 
+## Required ports
+
+To use SSL, the following ports must be open:
+- 443
+- 80
+
 ## Configure SSL for web traffic
 
 This procedure shows how to add SSL (secure socket layers) to enable secure HTTP (HTTPS) in ThoughtSpot. To set up SSL, you will need:

--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -856,8 +856,7 @@ Enables Spot integration.  This subcommand supports the following actions:
 
 ```
 tscli ssl [-h] {add-cert,clear-min-tls-version,off,on,rm-cert,set-min-tls-version,status,tls-status} ...
-```        
-
+```   
 This subcommand supports the following actions:
 
 * `tscli ssl add-cert [-h]` *`key`* *`certificate`* Adds an SSL certificate, key pair.
@@ -873,6 +872,12 @@ This subcommand supports the following actions:
 * `tscli ssl set-min-tls-version [-h] {1.0,1.1,1.2}` Sets the minimum supported TLS version. Sets the minimum SSL version to be supported by the ThoughtSpot application. Please ensure that client browsers are enabled for this version or newer.
 * `tscli ssl status` Shows whether SSL authentication is enabled or disabled.
 * `tscli ssl tls-status [-h]`  Prints the status of TLS support.
+
+##### Required ports for SSL
+
+To use SSL, the following ports must be open:
+- 443
+- 80
 
 ### sssd
 


### PR DESCRIPTION
### What's changed:
- Added required ports for SSL (80 and 443).
- Added to both SSL config and TSCLI reference pages.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>