### PR TITLE
5.3: SSL required ports doc update

### DIFF
--- a/_admin/setup/SSL-config.md
+++ b/_admin/setup/SSL-config.md
@@ -21,6 +21,13 @@ If you do not have an SSL certificate, there are options:
     ```
 ThoughtSpot works with a wide variety of SSL types, from a wide variety of vendors.
 
+{: id="ssl-ports"}
+## Required ports
+
+To use SSL, the following ports must be open:
+- 443
+- 80
+
 {: id="ssl-configure"}
 ## Configure SSL for web traffic
 

--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -908,6 +908,12 @@ This subcommand supports the following actions:
 * `tscli ssl status` Shows whether SSL authentication is enabled or disabled.
 * `tscli ssl tls-status [-h]`  Prints the status of TLS support.
 
+##### Required ports for SSL
+
+To use SSL, the following ports must be open:
+- 443
+- 80
+
 ### sssd
 
 ```


### PR DESCRIPTION
### What's changed:
• Added required ports for SSL (80 and 443).
• Added to both SSL config and TSCLI reference pages.