### PR TITLE
SCAL-50492 added new information about number of nodes

### DIFF
--- a/_appliance/vmware/vmware-setup.md
+++ b/_appliance/vmware/vmware-setup.md
@@ -1,6 +1,6 @@
 ---
 title: [Set up VMware for ThoughtSpot]
-
+summary: Learn how to install a ThoughtSpot cluster in a VMware environment.
 last_updated: tbd
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
@@ -16,10 +16,10 @@ a virtual machine (VM)
 ## Prerequisites
 
 This installation process assumes you have already acquired your host machines.
-You can install on a one or three node cluster. A one node cluster is suitable
-for a sandbox environment but is insufficient for a production environment.
+You can install on a cluster with any number of nodes. A one node cluster is suitable
+for a sandbox environment but is insufficient for a production environment. You need at least three nodes for high availability (HA), but there is no limit on the number of nodes.
 
-1. Make sure you have installed the Hypervisor on each of your three nodes.
+1. Make sure you have installed the Hypervisor on each of your nodes.
 
    The VM template, by default, captures a 72-core configuration. If your
    physical host has more than 72 cores, you may want to edit VM to have (`n-2`)


### PR DESCRIPTION
Per SCAL-50492, specified that there is no limit on number of nodes for VMware installation, but that at least three are required for HA. Added summary to page.

Signed-off-by: Teresa Killmond <teresa.killmond@thoughtspot.com>