### PR TITLE
Updates to release notes, gcp setup page, and tscli command ref

### DIFF
--- a/_appliance/aws/launch-an-instance.md
+++ b/_appliance/aws/launch-an-instance.md
@@ -169,5 +169,5 @@ To determine which network ports to open for a functional ThoughtSpot cluster, s
 
 ## Related information  
 
-[EC2 Best Practices](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-best-practices.html)  
+[EC2 Best Practices](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-best-practices.html){:target="_blank"}  
 [Loading data from an AWS S3 bucket]({{site.baseurl }}/admin/loading/use-data-importer.html#loading-data-from-an-aws-s3-bucket)

--- a/_appliance/gcp/configuration-options.md
+++ b/_appliance/gcp/configuration-options.md
@@ -7,8 +7,8 @@ sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
 ThoughtSpot can be deployed in your GCP environment by deploying compute (VM) instances in your VPC as well as an underlying persistent storage infrastructure. Currently two configuration modes are supported by ThoughtSpot:
-- Mode 1: Compute VMs + Persistent Disk storage-only
-- Mode 2: Compute VMs + Persistent Disk and Google Cloud Storage (GCS).
+- Mode 1: Compute VMs + SSD Persistent Disk storage-only
+- Mode 2: Compute VMs + SSD Persistent Disk and Google Cloud Storage (GCS).
 
 For more information about Persistant Storage, see [Zonal Persistent SSD disks](https://cloud.google.com/compute/docs/disks/#pdspecs){:target="_blank"} in Google's Cloud documentation.
 

--- a/_appliance/gcp/launch-an-instance.md
+++ b/_appliance/gcp/launch-an-instance.md
@@ -158,4 +158,4 @@ To determine which network ports to open for a functional ThoughtSpot cluster, s
 ## Related information
 
 [Connecting to Google Cloud Storage buckets](https://cloud.google.com/compute/docs/disks/gcs-buckets){:target="_blank"}  
-[Loading data from an GCP GCS bucket]({{site.baseurl }}/admin/loading/use-data-importer.html#loading-data-from-a-gcp-gcs-bucket)
+[Loading data from a GCP GCS bucket]({{site.baseurl }}/admin/loading/use-data-importer.html#loading-data-from-a-gcp-gcs-bucket)

--- a/_appliance/gcp/launch-an-instance.md
+++ b/_appliance/gcp/launch-an-instance.md
@@ -157,5 +157,5 @@ To determine which network ports to open for a functional ThoughtSpot cluster, s
 
 ## Related information
 
-[Connecting to Google Cloud Storage buckets](https://cloud.google.com/compute/docs/disks/gcs-buckets)  
+[Connecting to Google Cloud Storage buckets](https://cloud.google.com/compute/docs/disks/gcs-buckets){:target="_blank"}  
 [Loading data from an GCP GCS bucket]({{site.baseurl }}/admin/loading/use-data-importer.html#loading-data-from-a-gcp-gcs-bucket)

--- a/_appliance/gcp/launch-an-instance.md
+++ b/_appliance/gcp/launch-an-instance.md
@@ -49,7 +49,7 @@ If you are going to deploy your cluster using the GCS-storage option, you must s
 
 8. For advanced settings, leave Encryption set to **Google-managed key**, do not set a retention policy, and click **CREATE**.
 
-When you create your instance, make sure you set Storage to **Full** access.
+When you create your instance, make sure you set Storage to **Read Write** access.
 
 ## Create an instance
 
@@ -124,7 +124,7 @@ When you create your instance, make sure you set Storage to **Full** access.
 8. (For use with GCS only) In the Identity and API access section, make sure Service account is set to **Compute Engine default service account**, and under Access scopes, select **Set access for each API**.
 
 9. (For use with GCS only) Scroll down to the Storage setting, and set it to one of the following options:
-   - To use Google Cloud Storage (GCS) as persistent storage for your instance, select **Full**.
+   - To use Google Cloud Storage (GCS) as persistent storage for your instance, select **Read Write**.
    - To only use GCS to load data into ThoughtSpot, select **Read Only**.
 
 10. Customize the network settings as needed, preferably use your default VPC settings.
@@ -154,3 +154,8 @@ If you are going to use GCS as your persistent storage, you must enable it when 
 ## Open the required network ports
 
 To determine which network ports to open for a functional ThoughtSpot cluster, see [Network policies]({{ site.baseurl }}/appliance/firewall-ports.html).
+
+## Related information
+
+[Connecting to Google Cloud Storage buckets](https://cloud.google.com/compute/docs/disks/gcs-buckets)  
+[Loading data from an GCP GCS bucket]({{site.baseurl }}/admin/loading/use-data-importer.html#loading-data-from-a-gcp-gcs-bucket)

--- a/_data-integrate/embrace/embrace-intro.md
+++ b/_data-integrate/embrace/embrace-intro.md
@@ -40,14 +40,15 @@ When you create your connection to an external database, by default, it is a **L
 | *Simple Search* | Yes | Yes |
 | *Complex searches like Versus, Inline Subquerying, Growth* | Yes | Yes |
 | *Search Suggestions for column names* | Yes | Yes |
-| *Search Suggestions for column values* | No | Yes |
+| *Search Suggestions for column values* | Yes | Yes |
 | *Headlines at the bottom that summarize tables* | Yes | Yes |
 | *All Chart Types & Configurations* | Yes | Yes |
 | *SpotIQ Instant Insights* | No | Yes |
 | *SpotIQ pre-computed insights* | No | Yes |
-| *Table and Column Remapping* | No | N/A |
+| *Table and Column Remapping* | Yes | N/A |
 | *Custom Calendar* | No | Yes |
 | *Materialized Views* | No | Yes |
+| *Indexing of table columns* | Yes | Yes |
 
 ## Next steps
 

--- a/_data-integrate/embrace/getting-started/modify-a-connection.md
+++ b/_data-integrate/embrace/getting-started/modify-a-connection.md
@@ -12,7 +12,7 @@ You can modify a connection in the following ways:
 - Delete a table
 - Delete a connection
 
-## Edit a connection
+## Editing a connection
 
 You can edit a connection to add tables and columns.
 
@@ -36,7 +36,7 @@ To edit a connection:
 
 To remove a table from a connection, delete it from the connection details page. For more information, see [Delete a table]({{ site.baseurl }}/data-integrate/embrace/getting-started/modify-a-connection.html#delete-a-table).
 
-## Remap a connection
+## Remapping a connection
 
 Modify the connection parameters by editing the source mapping<code> yaml </code>file that was created when you adding the connection. For example, you can remap the existing table or column to a different table or column in an existing database connection. ThoughtSpot recommends that you check the dependencies before and after you remap a table or column in a connection to ensure they display as intended.
 
@@ -62,7 +62,7 @@ To remap a connection:
 
 7. Finally, upload the mapping file to reflect the new mapping in the existing connection.
 
-## Delete a table
+## Deleting a table
 ThoughtSpot checks for dependencies whenever you try to remove a table in a connection. A list of dependent objects is shown, and you can click them to delete them or remove the dependency. Then you’ll be able to remove the table.
 
 To delete a table:
@@ -87,7 +87,7 @@ To delete a table:
 
 You can also click the name of a table and then click the linked objects to to see a list of dependent objects with links. The list shows the names of the dependent objects (worksheets, pinboards or answers), and the columns they use from that table. You can use this information to determine the impact of changing the structure of the data source or to see how widely used it is. Click a dependent object to modify or delete it.
 
-## Delete a connection
+## Deleting a connection
 A connection can be used in multiple data sources or visualizations. Because of this, you must delete all of the sources and tasks that use that connection, before you can delete the connection.
 
 To delete a connection:

--- a/_data-integrate/embrace/getting-started/setup-a-new-connection.md
+++ b/_data-integrate/embrace/getting-started/setup-a-new-connection.md
@@ -7,7 +7,7 @@ permalink: /:collection/:path.html
 ---
 Once ThoughtSpot Embrace is enabled, you can add a connection to a supported external database. This allows you to perform a live query of the external database to create answers and pinboards, without having to bring the data into ThoughtSpot.
 
-## Add a connection
+## Adding a connection
 
 To add a new connection:
 

--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -656,7 +656,7 @@ This subcommand has the following options:
       <dd><p>Disables cluster rotate key configuration.</p>
       <p>The default is <code>False</code>.</p></dd></dlentry>
       <dlentry>
-      <dt><code>--enable_cloud_storage {s3a,gcs}</code></code></dt>
+      <dt><code>--enable_cloud_storage {s3a,gcs}</code></dt>
       <dd>Determines whether to enable Cloud Storage setup, and which storage format to use.
       </dd></dlentry>
       <dlentry>

--- a/_release/notes.md
+++ b/_release/notes.md
@@ -37,7 +37,7 @@ First, upgrade to version 5.2.x, or version 5.3.x, and then to the 6.0 release.
 ## 6.0 New Features and Functionality
 
 ### Mobile
-You can now download ThoughtSpot Mobile app from the AppStore for both iPhone and iPAd devices. ThoughtSpot Mobile works for releases 5.1 and later.
+You can now download ThoughtSpot Mobile app from the AppStore for both iPhone and iPad devices. ThoughtSpot Mobile works for releases 5.1 and later.
 
 Mobile now includes supports auto-redirect Single Sign-On (SSO) for configured clusters.
 
@@ -64,16 +64,16 @@ TBD
 - [median function]({{ site.baseurl }}/reference/formula-reference.html#median)
 - [nth_percentile function]({{ site.baseurl }}/reference/formula-reference.html#nth_percentile) -->
 
-### Streamlined AWS data loading from an S3 bucket
-You can now load data from an S3 bucket into your ThoughtSpot AWS instance faster than ever before. By assigning an AWS IAM role to your instance which has read-only access to your S3 bucket, you no longer have to enter S3 credentials when loading data. For more information, see [Loading data from an AWS S3 bucket]({{ site.baseurl }}/admin/loading/use-data-importer.html#loading-data-from-an-aws-s3-bucket)
+### Streamlined GCP data loading from an GCS bucket
+You can now load data from an Google Cloud Storage (GCS) bucket into your ThoughtSpot GCP instance. By assigning the _Compute Engine default service account_ and the _Set access for each API_ scope to your instance, you can set read-only access to your GCS bucket. This way, you don't have to enter GCS credentials when loading data. For more information, see [Loading data from an GCP GCS bucket]({{ site.baseurl }}/admin/loading/use-data-importer.html#loading-data-from-a-gcp-gcs-bucket)
 
 {: id="6-fixed"}
 ## 6.0 Fixed Issues
 
 The following issues are fixed in the 6.0 release:
 
-- TBD
-- TBD
+- The `tscli cluster download-release` command sometimes does not work correctly.
+- The date dimension attribute is removed from the query for all date aggregations, except for DETAILED.
 
 {: id="beta-program"}
 ## Beta Programs

--- a/_release/notes.md
+++ b/_release/notes.md
@@ -57,12 +57,22 @@ Worksheet scriptability supports metadata migration from development to producti
 
 See [Migrate or restore Worksheets]({{ site.baseurl }}/admin/worksheets/worksheet-export.html), and [Worksheet YAML specification]({{ site.baseurl }}/admin/worksheets/yaml-worksheet.html)]
 
-### TBD
-TBD
+### Embrace now supports Amazon Redshift
+You can now perform live queries against an Amazon Redshift database without caching it in ThoughtSpot. You can then analyze the data and create visualizations in ThoughtSpot. As with Snowflake, you can sync the data into ThoughtSpot later, if you want. Support for **Amazon Redshift is in beta**.
+
+Also, the following features are now supported for linked tables:
+- Search suggestions for column values
+- Indexing of table columns
+- Remapping of tables and columns
+
+For more information, see [Embrace overview]({{ site.baseurl }}/data-integrate/embrace/embrace-intro.html).
 
 <!-- ### New group functions
 - [median function]({{ site.baseurl }}/reference/formula-reference.html#median)
 - [nth_percentile function]({{ site.baseurl }}/reference/formula-reference.html#nth_percentile) -->
+
+### Google Cloud Platform GCS persistent storage option
+You can now reduce the cost of an GCP deployment by using GCS for storage of major services like the ThoughtSpot database and search engine. For more information, see [GCP configuration options]({{ site.baseurl }}/appliance/gcp/configuration-options.html).
 
 ### Streamlined GCP data loading from an GCS bucket
 You can now load data from an Google Cloud Storage (GCS) bucket into your ThoughtSpot GCP instance. By assigning the _Compute Engine default service account_ and the _Set access for each API_ scope to your instance, you can set read-only access to your GCS bucket. This way, you don't have to enter GCS credentials when loading data. For more information, see [Loading data from an GCP GCS bucket]({{ site.baseurl }}/admin/loading/use-data-importer.html#loading-data-from-a-gcp-gcs-bucket)


### PR DESCRIPTION
### What's changed:
- Initial draft of 6.0 fixed issues
- Addition of loading from GCS bucket to release notes
- Updates to Set up GCP page to change req for Full access to GCS storage to Read Write
- Updates to Set up GCP page to add related links to load from GCS bucket and Google info on connecting GCS buckets

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>