### PR TITLE
6.0 pdf page dead links removed and data integration guide added

### DIFF
--- a/_release/pdfs.md
+++ b/_release/pdfs.md
@@ -9,11 +9,10 @@ permalink: /:collection/:path.html
 You can download ThoughtSpot 6.0 guides in PDF format.
 {% include note.html content="PDFs may not be as up-to-date as the HTML documentation, which we refresh more frequently between releases."%}
 
-* [User Guide](/6.0/pdf/ThoughtSpot_User_Guide_6.0.pdf)
 * [Administrator Guide](/6.0/pdf/ThoughtSpot_Administration_Guide_6.0.pdf)
 * [Embedding Guide](/6.0/pdf/ThoughtSpot_Application_Integration_Guide_6.0.pdf)
 * [Node Setup Guide](/6.0/pdf/ThoughtSpot_Node_Setup_Guide_6.0.pdf)
-* [Embedding Guide](/6.0/pdf/ThoughtSpot_Embedding_Guide_6.0.pdf)
+* [Data Integration Guide](/6.0/pdf/ThoughtSpot_Data_Integration_Guide_6.0.pdf)
 * [Disaster Recovery Guide](/6.0/pdf/ThoughtSpot_Disaster_Recovery_Guide_6.0.pdf)
 * [Reference Guide](/6.0/pdf/ThoughtSpot_Reference_Guide_6.0.pdf)
 * [Release Notes](/6.0/pdf/ThoughtSpot_Release_Notes_6.0.pdf)


### PR DESCRIPTION
### What's changed:
- user guide (missing) link removed
- embedding guide (extra link) removed
- data integration guide (link originally missing) added

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>