### PR TITLE
5.3 pdf page fix 

### DIFF
--- a/_release/pdfs.md
+++ b/_release/pdfs.md
@@ -9,11 +9,10 @@ permalink: /:collection/:path.html
 You can download ThoughtSpot 5.3 guides in PDF format.
 {% include note.html content="PDFs may not be as up-to-date as the HTML documentation, which we refresh more frequently between releases."%}
 
-* [User Guide](/5.3/pdf/ThoughtSpot_User_Guide_5.3.pdf)
 * [Administrator Guide](/5.3/pdf/ThoughtSpot_Administration_Guide_5.3.pdf)
 * [Embedding Guide](/5.3/pdf/ThoughtSpot_Application_Integration_Guide_5.3.pdf)
 * [Node Setup Guide](/5.3/pdf/ThoughtSpot_Node_Setup_Guide_5.3.pdf)
-* [Embedding Guide](/5.3/pdf/ThoughtSpot_Embedding_Guide_5.3.pdf)
+* [Data Integration Guide](/5.3/pdf/ThoughtSpot_Data_Integration_Guide_5.3.pdf)
 * [Disaster Recovery Guide](/5.3/pdf/ThoughtSpot_Disaster_Recovery_Guide_5.3.pdf)
 * [Reference Guide](/5.3/pdf/ThoughtSpot_Reference_Guide_5.3.pdf)
 * [Release Notes](/5.3/pdf/ThoughtSpot_Release_Notes_5.3.pdf)


### PR DESCRIPTION
### What's changed:
• User guide (missing) link removed
• Embedding guide (extra link) removed
• Data integration guide (link originally missing) added
