### PR TITLE
5.3: fixed broken link in sidebar to spotiq comparative analysis

### DIFF
--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -362,7 +362,7 @@ entries:
           url: /spotiq/special-topics.html
           output: web,ugBk
         - title: "Comparative Analysis"
-          url: /spotiq/comparative-anaysis.html
+          url: /spotiq/comparative-analysis.html
           output: web,ugBk
         - title: "Custom SpotIQ analysis"
           url: /spotiq/customization.html


### PR DESCRIPTION
### What's changed:
• Fixed broken link in sidebar to Users> SpotIQ > Comparative Analysis

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>