### PR TITLE
5.2: Added SpotIQ privilege description

### DIFF
--- a/_admin/users-groups/about-users-groups.md
+++ b/_admin/users-groups/about-users-groups.md
@@ -63,6 +63,7 @@ Permissions to see and edit tables, worksheets, and pinboards are set when you
 share them with users and groups, as described in the topic [Data security]({{
 site.baseurl }}/admin/data-security/sharing-security-overview.html#).
 
+The following table shows the intersection of user privilege and ability:
 {% include content/security-matrix.md %}
 
 ## Related information

--- a/_includes/content/privileges.md
+++ b/_includes/content/privileges.md
@@ -29,15 +29,12 @@
     </tr>
     <tr>
       <td><strong>Can manage data</strong></td>
-      td>Can create worksheets and views.<br>Note that to edit a worksheet or a view created by another user, you must have the **Edit** permission on that object, and it must be shared with you.</td>
+      <td>Can create worksheets and views.<br>Note that to edit a worksheet or a view created by another user, you must have the **Edit** permission on that object, and it must be shared with you.</td>
+    </tr>
     <tr>
       <td><strong>Can use experimental features</strong></td>
       <td>Can access trial and experimental features that ThoughtSpot makes available to early adopters.</td>
     </tr>
-<!--    <tr>
-      <td><strong>Can schedule pinboards</strong></td>
-      <td>Can create pinboard schedules and edit their own scheduled jobs.</td>
-    </tr> -->
     <tr>
       <td><strong>Can invoke Custom R Analysis</strong></td>
       <td>Can access R scripts to further explore search answers. Includes options to invoke R scripts on visualizations, create and share custom scripts, and share the results of R analysis as answers and pinboards.</td>
@@ -47,8 +44,12 @@
       <td>Can create pinboard schedules and edit their own scheduled jobs.</td>
     </tr>
     <tr>
+      <td><strong>Has SpotIQ privilege</strong></td>
+      <td>Can use the SpotIQ feature.<br>If this privilege is not enabled for the user, they can still see "Did you know" SpotIQ insights on the ThoughtSpot home page.</td>
+    </tr>
+    <tr>
       <td><strong>Can administer and bypass RLS</strong></td>
-      <td><p>Users in groups with this privilege (directly or via group inheritance):</p>
+      <td><p>Users in groups with this privilege (directly or through group inheritance):</p>
 <ul>      <li>Are exempt from row-level security (RLS) rules.</li>
       <li>Can add/edit/delete existing RLS rules.</li>
       <li>Can check or uncheck Bypass RLS on a worksheet.</li></ul>

--- a/_includes/content/security-matrix.md
+++ b/_includes/content/security-matrix.md
@@ -1,5 +1,4 @@
 <table id="matrix" class="wide_table" style="font-size:10px;">
-  <caption>The following table shows the intersection of user privilege and ability:</caption>
    <colgroup>
       <col style="width:36%;">
       <col style="width:4%;">
@@ -201,7 +200,7 @@
       </tr>
       <tr>
          <td>
-            <div>Can Auto-Analyze (SpotIQ privilege)</div>
+            <div>Has SpotIQ privilege</div>
          </td>
          <td>N</td>
          <td>N</td>


### PR DESCRIPTION
### What's changed:

• Added description of Has SpotIQ privilege and updated matrix on the admin and end-user pages that describe user privileges.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>