### PR TITLE
SCAL-52689 added pw reqs to release notes and two articles for 6.0

### DIFF
--- a/_admin/users-groups/add-user.md
+++ b/_admin/users-groups/add-user.md
@@ -70,7 +70,7 @@ To create a new user and assign that user to groups, follow these steps:
       <tr id="password">
         <th>Change password</th>
         <td>Yes</td>
-        <td>A password.</td>
+        <td>A password. Your password must contain three of the following: uppercase letters A-Z, lowercase letters a-z, numbers 0-9, special characters !#$ etc. Your password must be at least eight characters long. When you click on the <strong>change password</strong> field, a tooltip appears to tell you these requirements.</td>
       </tr>
       <tr id="confirm_password">
         <th>Confirm password</th>

--- a/_end-user/introduction/about-user.md
+++ b/_end-user/introduction/about-user.md
@@ -1,6 +1,6 @@
 ---
 title: [About your user profile]
-last_updated: 10/07/2019
+last_updated: 12/19/2019
 summary: "The user icon lets you view your profile, adjust language options, specify notification preferences, revisit onboarding, or sign out of ThoughtSpot."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
@@ -16,7 +16,7 @@ Click **Profile** to navigate to your profile, where you can change your icon, p
 Notice that you can now see the **My Profile** interface.
 
 {: id="profile-picture" }
-## Change you profile picture
+## Change your profile picture
 
 You can change your profile picture clicking the user profile in the top right of the interface, clicking **Upload Picture**, and selecting a new image from the file browser.
 
@@ -60,7 +60,7 @@ Select **Email me sharing notifications** to receive emails whenever another use
 
 When you are relatively new to using ThoughtSpot, we help you to become productive faster.
 
-Whenever you need a refresh, navigate to **My Profile*. Under **Preferences**, see the **New user onboarding** option. Click **Revisit**, and ThoughtSpot guides you through onboarding again.
+Whenever you need a refresh, navigate to **My Profile**. Under **Preferences**, see the **New user onboarding** option. Click **Revisit**, and ThoughtSpot guides you through onboarding again.
 
 ![]({{ site.baseurl }}/images/onboarding-revisit.png "Revisit onboarding")
 
@@ -71,6 +71,8 @@ When you need to change your password, navigate to **My Profile**, and under **P
   - Current Password
   - New Password
   - Confirm Password
+
+  {% include note.html content="Your password must contain three of the following: uppercase letters A-Z, lowercase letters a-z, numbers 0-9, special characters !#$ etc. Your password must be at least eight characters long." %}
 
 Click **Update**.
 

--- a/_release/notes.md
+++ b/_release/notes.md
@@ -178,6 +178,9 @@ ThoughtSpot now supports [GeoMap]({{ site.baseurl }}/reference/geomap-reference.
 - <strong>Italy:</strong> Region, Province/Territories, and Postal Code
 - <strong>Poland:</strong> Province/Territories, County, Postal Code
 
+### Updated password requirements
+This release added password requirements for new and existing users. When a user changes their password or an administrator adds a new user, ThoughtSpot requires a more complex password. Your password must contain three of the following: uppercase letters A-Z, lowercase letters a-z, numbers 0-9, special characters !#$ etc. Your password must be at least eight characters long.
+
 {: id="6-fixed"}
 ## 6.0 Fixed Issues
 


### PR DESCRIPTION
Per SCAL-50283 and SCAL-52689, added password requirements to release notes, adding a user admin article, and user profile article.

Signed-off-by: Teresa Killmond <teresa.killmond@thoughtspot.com>