### PR TITLE
pdf build script tweaks

### DIFF
--- a/pdf-build.sh
+++ b/pdf-build.sh
@@ -65,7 +65,7 @@ for book in $(echo "$bookList" | jq -r '.books[] | @base64'); do
     echo "done";
 
     echo "Building the PDF ...";
-    prince --javascript --pdf-keywords=prince-no-fallback --input-list=_site/pdfconfigs/prince-list.txt -o pdf/${theName}_${theVersion}.pdf;
+    prince --javascript --pdf-keywords=prince-no-fallback --input-list=_site/pdfconfigs/prince-list.txt -o pdf/${theName}_${theVersion}.pdf --baseurl=docs.thoughtspot.com/6.0/;
 
 
     ## Reset everything for the next book


### PR DESCRIPTION
### What's changed:
- Tweaked pdf build script to add `baseurl` parameter to fix page zero links to doc site pages

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>