### PR TITLE
Fixed the title of the page.

### DIFF
--- a/_admin/setup/active-directory-based-access.md
+++ b/_admin/setup/active-directory-based-access.md
@@ -1,5 +1,5 @@
 ---
-title: [Enable Active Directory based access]
+title: [Enable Active Directory based access for ThoughtSpot backend]
 
 
 last_updated: tbd


### PR DESCRIPTION
This needs to be updated retrospectively from docs version 5.1 onwards.
We need to clearly indicate that the access is for backend and not the front-end.

Once the change has been committed, the git branch can be deleted.
CC @mark-plummer 