### PR TITLE
Correctly highlight choices of instance type

### DIFF
--- a/_appliance/azure/launch-an-instance.md
+++ b/_appliance/azure/launch-an-instance.md
@@ -94,7 +94,7 @@ Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/).
 
 ### Choose a machine size
 
-Under **Choose a size**, select `E64S_V3 standard`. For more information, refer to [Azure configuration options]({{ site.baseurl }}/appliance/azure/configuration-options.html).
+Under **Choose a size**, select  `E64S_V3 standard`. For more information, refer to [Azure configuration options]({{ site.baseurl }}/appliance/azure/configuration-options.html).
 
 ![]({{ site.baseurl }}/images/azure_choose_disk_size.png "Choose a disk size")
 


### PR DESCRIPTION
E64S_V3 standard is not the only instance type offered now. 
We need to either provide a hardcoded list all available instances (bad) or provide users with a URL of webpage containing available instance types in Azure so that the users can choose instance size based upon their purchased/required capacity).