### PR TITLE
mobile app 1.2 release notes

### DIFF
--- a/_admin/mobile/notes-mobile.md
+++ b/_admin/mobile/notes-mobile.md
@@ -5,8 +5,22 @@ last_updated: tbd
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-ThoughtSpot mobile 1.1.2 is now available. These release notes include information about new features,
+ThoughtSpot mobile 1.2 is now available. These release notes include information about new features,
 fixed issues from the previous releases, and any known issues.
+
+{: id="1-2-new"}
+## 1.2 New Features and Functionality
+- R charts are now supported.
+- Data labels are now available on the iPad version for enhanced chart viewing.
+- Quick support. If you have any issues, you can now share debug logs with the ThoughtSpot mobile team, from the profile page.
+
+{: id="1-2-fixed"}
+## 1.2 Fixed Issues
+
+The following issues are fixed in the 1.2 release:
+
+- Users can interact with "View Only" filters on Pinboards.
+- Year data labels are off by one year when custom calendar settings are used.
 
 {: id="1-1-2-new"}
 ## 1.1.2 New Features and Functionality

--- a/_admin/mobile/use-mobile.md
+++ b/_admin/mobile/use-mobile.md
@@ -5,9 +5,9 @@ last_updated: tbd
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-ThoughtSpot mobile allows you to discover insights in seconds from billions of rows of data, right from the palm of your hand. You can access your ThoughtSpot cluster to search answers and pinboards. You can also create pinboards using existing answers and use pinboard filters.
+The ThoughtSpot mobile app allows you to discover insights in seconds from billions of rows of data, right from the palm of your hand. You can access your ThoughtSpot cluster to search answers and pinboards. You can also create pinboards using existing answers and use pinboard filters.
 
-Mobile version 1.1.2 now supports auto-redirect Single Sign-On (SSO) for configured clusters.
+Version 1.2 now supports R charts, enhanced chart-viewing for iPad, and quick support. For details, see [Mobile release notes]({{ site.baseurl }}/admin/mobile/notes-mobile.html#).
 
 ## Requirements
 


### PR DESCRIPTION
### What's changed:
- added mobile 1.2 release notes.
- updated mobile overview page to reference v1.2.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>