### PR TITLE
Fix embedded URLs for docs.thoughtspot.com

### DIFF
--- a/_admin/setup/work-with-ts-support.md
+++ b/_admin/setup/work-with-ts-support.md
@@ -108,7 +108,7 @@ To enable remote support, follow these steps:
     $ tscli support stop-remote
     ```
 
-    You can repeat the steps to start and stop the remote tunnel as needed for future support operations.
+    You can repeat the steps to start and stop the remote tunnel as needed for future support operations. 
 
 9. Ensure that the remote tunnel is disabled:
 


### PR DESCRIPTION
Section "Using remote support with tscli" item "Contact ThoughtSpot Support (https://docs.thoughtspot.com/6.0/admin/misc/contact.html)... " has the URL quoted in simple text.

The URL should probably be parameterised for the release number (Instead of 6.0 we should have <release-version> or similar) and the URL should be hidden behind text "ThoughtSpot Support" instead of being expanded next to it.

Same for item-7 : Contact ThoughtSpot Support (https://docs.thoughtspot.com/latest/admin/misc/contact.html) and test your setup.