### PR TITLE
Circular instructions : need fixing

### DIFF
--- a/_admin/misc/contact.md
+++ b/_admin/misc/contact.md
@@ -4,6 +4,6 @@ title: [Contact ThoughtSpot]
 last_updated: tbd
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
----
+--- 
 
 {% include content/contact-info.md %}


### PR DESCRIPTION
Text says "You need a Support Portal login to file a ticket. Please contact ThoughtSpot to get an account, if necessary."

This can be confusing to customers. How do I reach ThoughtSpot if I don't have a login?

Can the text be changed to "You need a Support Portal account to file a ticket. If one hasn't been set up for you, please reach out to your ThoughtSpot liaison or email ThoughtSpot support using the details provided below".

Please review and amend if suitable.