### PR TITLE
SCAL-53690 specifying zookeeper ports are RPC, but TCP protocol

### DIFF
--- a/_admin/setup/firewall-ports.md
+++ b/_admin/setup/firewall-ports.md
@@ -2,7 +2,7 @@
 title: [Network ports]
 tags:
 keywords: network, ports
-last_updated: tbd
+last_updated: 1/17/2020
 summary: "Lists the required and optional ports for an installation."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html

--- a/_includes/content/ports-network.md
+++ b/_includes/content/ports-network.md
@@ -11,7 +11,7 @@ Internally, ThoughtSpot uses static ports for communication between services in 
 |443|TCP|Secure nginx|inbound|All nodes|All nodes|Primary app HTTPS port (nginx)|
 |2100|RPC|Oreo RPC port|bidirectional|All nodes|All nodes|Node daemon RPC|
 |2101|HTTP|Oreo HTTP port|bidirectional|Admin IP addresses and all nodes|All nodes|Node daemon HTTP|
-|2181|RPC|Zookeeper servers listen on this port for client connections|bidirectional|All nodes|All nodes|Zookeeper servers listen on this port for client connections|
+|2181|TCP|Zookeeper servers listen on this RPC port for client connections|bidirectional|All nodes|All nodes|Zookeeper servers listen on this RPC port for client connections|
 |2200|RPC|Orion master RPC port|bidirectional|All nodes|All nodes|Internal communication with the cluster manager|
 |2201|HTTP|Orion master HTTP port|bidirectional|Admin IP addresses and all nodes|All nodes|Port used to debug the cluster manager|
 |2210|RPC|Cluster stats service RPC port|bidirectional|All nodes|All nodes|Internal communication with the stats collector|


### PR DESCRIPTION
Signed-off-by: Teresa Killmond <teresa.killmond@thoughtspot.com>