### PR TITLE
SCAL-36938, cable ref sidebar fix, html to markdown for pdf

### DIFF
--- a/_appliance/azure/launch-an-instance.md
+++ b/_appliance/azure/launch-an-instance.md
@@ -1,6 +1,6 @@
 ---
 title: [Set up ThoughtSpot in Azure]
-last_updated: 1/22/2020
+last_updated: 3/3/2020
 summary: "After you determine your configuration options, you must set up your virtual
 machines using a ThoughtSpot image for Azure."
 sidebar: mydoc_sidebar
@@ -33,7 +33,7 @@ Complete these steps before launching your ThoughtSpot Virtual Machine:
 1. Obtain an Azure login account.
 2. Set up usage payment details with Microsoft Azure.
 3. Find your company's [Resource Group](https://portal.azure.com/#blade/HubsExtension/BrowseResourceGroups). (optional--you can also create one while creating your virtual machines.)
-4. <a href="{{ site.baseurl }}/site-survey.pdf" download>Download</a> and fill out the ThoughtSpot site survey to have a quick reference for any networking information you may need to fill out. Ask your network administrator if you need help filling out the site survey.
+4. Download and fill out the ThoughtSpot [site survey]({{ site.baseurl }}/site-survey.pdf){:target="_blank"} to have a quick reference for any networking information you may need to fill out. Ask your network administrator if you need help filling out the site survey.
 
 {: id="create-instance"}
 ### Create an instance
@@ -87,7 +87,7 @@ Create your virtual machines based on the [ThoughtSpot Virtual Machine](https://
     | **2** | Find your company's public IP, or **create new**. |
     | **3** | Select **Advanced** for *NIC network security group*. |
     | **4** | After you select **Advanced**, the **Configure network security group** option appears. Find your company's security group, or **create new**. When creating your security group, ensure that the required ports are open. Refer to the [minimum port requirements](#port-requirements). |
-    
+
 5. Under **Management**, configure your monitoring and management preferences. If you have no preferences, you can leave them at their default settings.
 
 6. Under **Advanced**, configure your advanced settings preferences. If you have no preferences, you can leave them at their default settings.

--- a/_appliance/gcp/launch-an-instance.md
+++ b/_appliance/gcp/launch-an-instance.md
@@ -1,7 +1,7 @@
 ---
 title: [Set up ThoughtSpot in GCP]
 summary: Set up your GCP virtual machines.
-last_updated: 2/27/2020
+last_updated: 3/3/2020
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
@@ -25,7 +25,7 @@ The following topics walk you through this process.
 
 1. Ensure that your **Network Service Tier** on the [Google Cloud Console](https://console.cloud.google.com/) is set to **Premium** for the best performance of all your VMs.
 2. A ThoughtSpot cluster requires 10 Gb/s bandwidth (or better) between any two nodes. You must ensure this *before* creating a new cluster.
-3. <a href="{{ site.baseurl }}/site-survey.pdf" download>Download</a> and fill out the ThoughtSpot site survey to have a quick reference for your networking information. Ask your network administrator if you need help filling out the site survey.
+3. Download and fill out the ThoughtSpot [site survey]({{ site.baseurl }}/site-survey.pdf){:target="_blank"} to have a quick reference for your networking information. Ask your network administrator if you need help filling out the site survey.
 
 ## Setting up your Google Cloud Storage (GCS) bucket
 

--- a/_appliance/hardware/cable-networking.md
+++ b/_appliance/hardware/cable-networking.md
@@ -1,7 +1,7 @@
 ---
 title: [Cable networking]
-summary: This section reviews the types of cables needed for 10GbE networking and how to plug them in.
-last_updated: 12/12/2019
+summary: This section reviews the types of cables needed for 10GbE networking with your Dell or SMC appliance, and how to plug them in.
+last_updated: 3/3/2020
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
@@ -20,7 +20,7 @@ Fiber can be run long distances to the switch.
 
 These cables require gigabit interface converters (GBICs), SFP+ form factor.
 
-**Remember:** ThoughtSpot does not supply cables or GBICs
+**Remember:** ThoughtSpot does not supply cables. Your Dell appliance may come with one appliance-side SFP+ per node, but not the switch-side SFP+'s.
 
 ![]({{ site.baseurl }}/images/gbics.png "GBICs")
 

--- a/_appliance/hardware/configure-management-dell.md
+++ b/_appliance/hardware/configure-management-dell.md
@@ -1,7 +1,7 @@
 ---
 title: [Configure the Dell Management Settings]
 summary: "Configure the management settings for Dell before you can deploy ThoughtSpot."
-last_updated: 2/7/2020
+last_updated: 3/3/2020
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
@@ -16,7 +16,7 @@ Input your specific network information to configure the management settings for
 
     ![Select network]({{ site.baseurl }}/images/dell-select-network.png "Select network")
 
-5. **Fill out the iDRAC settings form** Add your specific network information for the IP address, Gateway, and Netmask in the empty boxes. DNS information is optional. <a href="{{ site.baseurl }}/site-survey.pdf" download>Download</a> and fill out the ThoughtSpot site survey for a quick reference, and ask your network administrator for help if you have not filled out the site survey yet.
+5. **Fill out the iDRAC settings form** Add your specific network information for the IP address, Gateway, and Netmask in the empty boxes. DNS information is optional. Download and fill out the ThoughtSpot [site survey]({{ site.baseurl }}/site-survey.pdf){:target="_blank"} for a quick reference, and ask your network administrator for help if you have not filled out the site survey yet.
     {% include warning.html content="If you configure DNS servers, you must only configure two servers. ThoughtSpot does not support configuration of three DNS servers." %}
 * For **Enable IPv4**, select **enabled**.
 * For **Enable DHCP**, select **disabled**.

--- a/_appliance/hardware/configure-nodes-dell.md
+++ b/_appliance/hardware/configure-nodes-dell.md
@@ -1,31 +1,17 @@
 ---
 title: [Configure Nodes]
 summary: "Configure ThoughtSpot nodes on your Dell appliance."
-last_updated: 1/22/2020
+last_updated: 3/3/2020
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
 {: id="configure-nodes"}
 After you connect the appliance, a command line appears on your console. Configure the nodes on this command line. Follow the steps in this checklist.
 
-<table>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-dell#node-step-1">Step 1: Get a template for network configuration</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-dell#node-step-2">Step 2: Prepare node configuration</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-dell#node-step-3">Step 3: Configure the nodes</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-dell#node-step-4">Step 4: Confirm node configuration</a></td>
-  </tr>
-</table>
+| &#10063; | [Step 1: Get a template for network configuration](#node-step-1) |
+| &#10063; | [Step 2: Prepare node configuration](#node-step-2) |
+| &#10063; | [Step 3: Configure the nodes](#node-step-3) |
+| &#10063; | [Step 4: Confirm node configuration](#node-step-4) |
 
 {: id="node-step-1"}
 ## Step 1: Get a template for network configuration

--- a/_appliance/hardware/configure-nodes-smc.md
+++ b/_appliance/hardware/configure-nodes-smc.md
@@ -7,32 +7,12 @@ permalink: /:collection/:path.html
 ---
 After you connect the appliance, configure the nodes in your Mac or Windows terminal emulator. Follow the steps in this checklist.
 
-<table>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-smc#node-step-1">Step 1: SSH into your cluster</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-smc#node-step-2">Step 2: Change to the <code>install</code> directory</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-smc#node-step-3">Step 3: Get a template for network configuration</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-smc#node-step-4">Step 4: Prepare node configuration</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-smc#node-step-5">Step 5: Configure the nodes</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-smc#node-step-6">Step 6: Confirm node configuration</a></td>
-  </tr>
-</table>
+| &#10063; | [Step 1: SSH into your cluster](#node-step-1) |
+| &#10063; | [Step 2: Change to the `install` directory](#node-step-2) |
+| &#10063; | [Step 3: Get a template for node configuration](#node-step-3) |
+| &#10063; | [Step 4: Prepare node configuration](#node-step-4) |
+| &#10063; | [Step 5: Configure the nodes](#node-step-5) |
+| &#10063; | [Step 6: Confirm node configuration](#node-step-6) | 
 
 If you completed ThoughtSpot's [site survey]({{ site.baseurl }}/site-survey.pdf){:target="_blank"} form and returned it to [ThoughtSpot Support]({{ site.baseurl }}/appliance/contact.html) before ThoughtSpot shipped the appliance, the appliance may be pre-configured for your network environment and ready to install and connect to your network.
 

--- a/_appliance/hardware/connect-appliance-dell.md
+++ b/_appliance/hardware/connect-appliance-dell.md
@@ -1,30 +1,16 @@
 ---
 title: [Connect the Appliance]
 summary: "Connect your Dell appliance before you can deploy ThoughtSpot."
-last_updated: 12/16/2019
+last_updated: 3/3/2020
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
 After you rack and stack the appliance, it is time to configure it. Follow the steps in this checklist.
 
-<table>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="connect-appliance-dell#appliance-step-1">Step 1: Connect switches to 10GbE ports</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="connect-appliance-dell#appliance-step-2">Step 2: Connect iDRAC ports</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="connect-appliance-dell#appliance-step-3">Step 3: Connect a keyboard and monitor</a></td>
-  </tr>  
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="connect-appliance-dell#appliance-step-4">Step 4: Turn on nodes</a></td>
-  </tr>
-</table>  
+| &#10063; | [Step 1: Connect switches to 10GbE ports](#appliance-step-1) |
+| &#10063; | [Step 2: Connect iDRAC ports](#appliance-step-2) |
+| &#10063; | [Step 3: Connect a keyboard and monitor](#appliance-step-3) |
+| &#10063; | [Step 4: Turn on nodes](#appliance-step-4) |
 
 {: id="appliance-step-1"}
 ## Step 1: Connect switches to 10GbE ports

--- a/_appliance/hardware/connect-appliance-smc.md
+++ b/_appliance/hardware/connect-appliance-smc.md
@@ -7,24 +7,10 @@ permalink: /:collection/:path.html
 ---
 After you rack and stack the appliance, it is time to configure it. If necessary, review the [Hardware Appliance Overview]({{ site.baseurl }}/appliance/hardware/inthebox.html). Follow the steps in this checklist.
 
-<table>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="connect-appliance-smc#appliance-step-1">Step 1: Connect switches to 10GbE ports</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="connect-appliance-smc#appliance-step-2">Step 2: Connect IPMI ports</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="connect-appliance-smc#appliance-step-3">Step 3: Turn on nodes</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="connect-appliance-smc#appliance-step-4">Step 4: Log in</a></td>
-  </tr>
-</table>
+| &#10063; | [Step 1: Connect switches to 10GbE ports](#appliance-step-1) |
+| &#10063; | [Step 2: Connect IPMI ports](#appliance-step-2) |
+| &#10063; | [Step 3: Turn on nodes](#appliance-step-3) |
+| &#10063; | [Step 4: Log in](#appliance-step-4) |
 
 {: id="appliance-step-1"}
 ## Step 1: Connect switches to 10GbE ports

--- a/_appliance/hardware/install-cluster-dell.md
+++ b/_appliance/hardware/install-cluster-dell.md
@@ -1,7 +1,7 @@
 ---
 title: [Install Cluster]
 summary: "Install your ThoughtSpot cluster(s) on your Dell appliance."
-last_updated: 2/6/2020
+last_updated: 3/3/2020
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
@@ -12,20 +12,9 @@ Refer to your welcome letter from ThoughtSpot to find the link to download the r
 
 Follow the steps in this checklist to install your cluster.
 
-<table>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="install-cluster-dell#install-step-1">Step 1: Run the installer</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="install-cluster-dell#install-step-2">Step 2: Check cluster health</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="install-cluster-dell#install-step-3">Step 3: Finalize installation</a></td>
-  </tr>
-</table>
+| &#10063; | [Step 1: Run the installer](#install-step-1) |
+| &#10063; | [Step 2: Check cluster health](#install-step-2) |
+| &#10063; | [Step 3: Finalize installation](#install-step-3) |
 
 {: id="install-step-1"}
 ## Step 1: Run the installer

--- a/_appliance/hardware/installing-dell.md
+++ b/_appliance/hardware/installing-dell.md
@@ -1,38 +1,18 @@
 ---
 title: [Deploying on the Dell appliance]
 summary: "Follow these steps to deploy ThoughtSpot on your Dell appliance."
-last_updated: 2/26/2020
+last_updated: 3/3/2020
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
 Follow the steps in this checklist to deploy ThoughtSpot on your Dell appliance.
 
-<table>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="prerequisites-dell.html">Step 1: Complete installation prerequisites</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="hardware-requirements-dell.html">Step 2: Review hardware requirements</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="connect-appliance-dell.html">Step 3: Connect your appliance</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-management-dell.html">Step 4: Configure management settings</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-dell.html">Step 5: Configure nodes</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="install-cluster-dell.html">Step 6: Install cluster</a></td>
-  </tr>
-</table>
+| &#10063; | [Step 1: Complete installation prerequisites]({{ site.baseurl }}/appliance/hardware/prerequisites-dell.html) |
+| &#10063; | [Step 2: Review hardware requirements]({{ site.baseurl }}/appliance/hardware/hardware-requirements-dell.html) |
+| &#10063; | [Step 3: Connect your appliance]({{ site.baseurl }}/appliance/hardware/connect-appliance-dell.html) |
+| &#10063; | [Step 4: Configure management settings]({{ site.baseurl }}/appliance/hardware/configure-management-dell.html) |
+| &#10063; | [Step 5: Configure nodes]({{ site.baseurl }}/appliance/hardware/configure-nodes-dell.html) |
+| &#10063; | [Step 6: Install cluster]({{ site.baseurl }}/appliance/hardware/install-cluster-dell.html) |
 
 ## Related information
 Use these references to aid you in successful installation and administration of ThoughtSpot.

--- a/_appliance/hardware/installing-the-smc.md
+++ b/_appliance/hardware/installing-the-smc.md
@@ -1,6 +1,6 @@
 ---
 title: [Deploying on the SMC appliance]
-last_updated: [2/26/2020]
+last_updated: [3/3/2020]
 summary: "Follow these steps to deploy ThoughtSpot on your Super Micro Computer appliance."
 sidebar: mydoc_sidebar
 toc: false
@@ -8,28 +8,11 @@ permalink: /:collection/:path.html
 ---
 Follow these steps to deploy ThoughtSpot on your Super Micro Computer (SMC) appliance.
 
-<table>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="prerequisites-smc.html">Step 1: Complete prerequisites</a></td>  
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="hardware-requirements-smc.html">Step 2: Review hardware requirements</a></td>  
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="connect-appliance-smc.html">Step 3: Connect the SMC appliance</a></td>  
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="configure-nodes-smc.html">Step 4: Configure nodes</a></td>  
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="smc-cluster-install.html">Step 5: Install cluster</a></td>  
-  </tr>
-</table>  
+| &#10063; | [Step 1: Complete installation prerequisites]({{ site.baseurl }}/appliance/hardware/prerequisites-smc.html) |
+| &#10063; | [Step 2: Review hardware requirements]({{ site.baseurl }}/appliance/hardware/hardware-requirements-smc.html) |
+| &#10063; | [Step 3: Connect your SMC appliance]({{ site.baseurl }}/appliance/hardware/connect-appliance-smc.html) |
+| &#10063; | [Step 4: Configure nodes]({{ site.baseurl }}/appliance/hardware/configure-nodes-smc.html) |
+| &#10063; | [Step 5: Install cluster]({{ site.baseurl }}/appliance/hardware/smc-cluster-install.html) |
 
 ## Related information
 Use these references to aid you in successful installation and administration of ThoughtSpot.

--- a/_appliance/hardware/prerequisites-dell.md
+++ b/_appliance/hardware/prerequisites-dell.md
@@ -1,53 +1,23 @@
 ---
 title: [Prerequisites]
 summary: "Complete these prerequisites to deploy ThoughtSpot on your Dell appliance."
-last_updated: 2/4/2020
+last_updated: 3/3/2020
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
 ## Installation prerequisites
 Ensure that you have the following items, information, and understanding of policies before you begin installing your Dell 6420 appliance.
 
-<table>
-<tr>
-<td>&#10063;</td>
-<td>10gbE switch with IPv6 broadcast and multicast enabled. You need one switch for each cluster, with one port for each node on the cluster.</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>Data center with proper environment controls, such as cooling.</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>AC power</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>10G connection: SFP+ for the switch side</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>10GbE network cables, either direct attach copper (DAC) or fiber. See <a href="cable-networking.html">Cable Reference</a> for more information to decide between the two types.</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>100Mbps or 1Gbps switch for connection to the iDRAC (Out of Band Management) port. You need one for each node in your cluster.</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>Cat5 network cables, for iDRAC/ management port use. You need one for each node.</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>Rack space of 2U or 3.5 inches for each appliance, and a power strip</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>VGA Monitor and USB keyboard</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>Networking information: IP addresses for data & management NICs, for up to 2 DNS servers, up to 4 NTP servers and for the default gateway. Ensure that you only configure two DNS servers. ThoughtSpot does not support configuration of three DNS servers. You also need to know the timezone for your cluster. Typically, your timezone is where most of the people who will use the product are. <a href="{{ site.baseurl }}/site-survey.pdf" download>Download</a> and fill out the ThoughtSpot site survey so that you have a quick reference. Contact your network administrator if you need help filling out the site survey. </td></tr></table>
+| &#10063; | 10gbE switch with IPv6 broadcast and multicast enabled. You need one switch for each cluster, with one port for each node on the cluster. |
+| &#10063; | Data center with proper environment controls, such as cooling. |
+| &#10063; | AC power |
+| &#10063; | 10G connection: You need one SFP+ for each node for the switch side. Dell supplies SFP+'s for the appliance side. |
+| &#10063; | 10GbE network cables, either direct attach copper (DAC) or fiber. See the [cable reference]({{ site.baseurl }}/appliance/hardware/cable-networking.html) for more information to decide between the two types. |
+| &#10063; | 100Mbps or 1Gbps switch for connection to the iDRAC (Out of Band Management) port. You need one for each node in your cluster. |
+| &#10063; | Cat5 network cables, for iDRAC/ management port use. You need one for each node. |
+| &#10063; | Rack space of 2U or 3.5 inches for each appliance, and a power strip. |
+| &#10063; | VGA Monitor and USB keyboard |
+| &#10063; | Networking information: IP addresses for data & management NICs, for up to 2 DNS servers, up to 4 NTP servers and for the default gateway. Ensure that you only configure two DNS servers. ThoughtSpot does not support configuration of three DNS servers. You also need to know the timezone for your cluster. Typically, your timezone is where most of the people who will use the product are. Download and fill out the ThoughtSpot [site survey]({{ site.baseurl }}/site-survey.pdf){:target="_blank"} so that you have a quick reference. Contact your network administrator if you need help filling out the site survey. |
 
 ## Review hardware requirements
 Next, [review hardware requirements.]({{ site.baseurl }}/appliance/hardware/hardware-requirements-dell.html)

--- a/_appliance/hardware/prerequisites-smc.md
+++ b/_appliance/hardware/prerequisites-smc.md
@@ -1,6 +1,6 @@
 ---
 title: [Prerequisites]
-last_updated: [2/4/2020]
+last_updated: [3/3/2020]
 summary: "Complete these prerequisites before installing your ThoughtSpot clusters on the SMC appliance."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
@@ -11,54 +11,18 @@ permalink: /:collection/:path.html
 
 Ensure that you have the following items, information, and understanding of policies before you begin deploying ThoughtSpot on your SMC appliance.
 
-<table>
-<tr>
-<td>&#10063;</td>
-<td><a href="/appliance/hardware/connect-appliance-smc.html#haswell-port-location">Appliance Port Location</a>, to locate data and IPMI ports.</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>Data center with proper environment controls, such as cooling.</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>AC power</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>10GbE switch, with enabled IPv6 broadcast and multicast. You need one switch for each cluster, with one port for each node on the cluster.</td></tr>
-<tr>
-<td>&#10063;</td>
-<td>10GbE network cables, either direct attach copper (DAC) or fiber. Refer to the <a href="cable-networking.html">Cable reference</a> for more information to decide between the two types.</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>100Mbps or 1Gbps switch for IPMI, for Out of Band Management. You need one for each node in your cluster.</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>Cat5 network cables, for IPMI management port use. You need one for each node.</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>Rack space of 2U or 3.5 inches for each appliance, and a power strip</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>VGA Monitor and USB keyboard</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>10G connection: SFP+ for the switch side</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td>Networking information: IP addresses for data & management NICs, for up to 2 DNS servers, up to 4 NTP servers and for the default gateway. Ensure that you configure only two DNS servers. ThoughtSpot does not support configuration of three DNS servers. You also need to know the timezone for your cluster. Typically, your timezone is where most of the people who will use the product are. <a href="{{ site.baseurl }}/site-survey.pdf" download>Download</a> and fill out the ThoughtSpot site survey so that you have a quick reference before beginning the install process. Ask your network administrator if you need help filling out the site survey.</td></tr>
-
-<tr>
-<td>&#10063;</td>
-<td><a href="{{ site.baseurl }}/appliance/firewall-ports.html">Network policies</a>, to determine the ports you need to have open for your cluster.</td></tr>
-</table>
+| &#10063; | [Appliance Port Location]({{ site.baseurl }}/appliance/hardware/connect-appliance-smc.html#haswell-port-location), to locate data and IPMI ports. |
+| &#10063; | Data center with proper environment controls, such as cooling.|
+| &#10063; | AC power |
+| &#10063; | 10GbE switch, with enabled IPv6 broadcast and multicast. You need one switch for each cluster, with one port for each node on the cluster. |
+| &#10063; | 10GbE network cables, either direct attach copper (DAC) or fiber. Refer to the [cable reference]({{ site.baseurl }}/appliance/hardware/cable-networking.html) for more information to decide between the two types. |
+| &#10063; | 100Mbps or 1Gbps switch for IPMI, for Out of Band Management. You need one for each node in your cluster. |
+| &#10063; | Cat5 network cables, for IPMI management port use. You need one for each node. |
+| &#10063; | Rack space of 2U or 3.5 inches for each appliance, and a power strip. |
+| &#10063; | VGA Monitor and USB keyboard |
+| &#10063; | 10G connection: You need one SFP+ for each node for the switch side, and one SFP+ for each node for the appliance side. |
+| &#10063; | Networking information: IP addresses for data & management NICs, for up to 2 DNS servers, up to 4 NTP servers and for the default gateway. Ensure that you configure only two DNS servers. ThoughtSpot does not support configuration of three DNS servers. You also need to know the timezone for your cluster. Typically, your timezone is where most of the people who will use the product are. Download and fill out the ThoughtSpot [site survey]({{ site.baseurl }}/site-survey.pdf){:target="_blank"} so that you have a quick reference before beginning the install process. Ask your network administrator if you need help filling out the site survey. |
+| &#10063; | [Network policies]({{ site.baseurl }}/appliance/firewall-ports.html), to determine the ports you need to have open for your cluster. |
 
 ## Review hardware requirements
 Next, [review hardware requirements]({{ site.baseurl }}/appliance/hardware/hardware-requirements-smc.html).

--- a/_appliance/hardware/smc-cluster-install.md
+++ b/_appliance/hardware/smc-cluster-install.md
@@ -1,6 +1,6 @@
 ---
 title: [Install ThoughtSpot Clusters on the SMC Appliance]
-last_updated: [2/6/2020]
+last_updated: [3/3/2020]
 summary: "Install your clusters on the SMC appliance."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
@@ -9,7 +9,13 @@ Install the cluster using the ThoughtSpot software release bundle. Installation 
 
 Refer to your welcome letter from ThoughtSpot to find the link to download the release bundle. If you have not received a link to download the release bundle, open a support ticket at [ThoughtSpot Support](https://support.thoughtspot.com) to access the release bundle.
 
-{: id="run-installer"}
+Follow the steps in this checklist to install your cluster.
+
+| &#10063; | [Step 1: Run the installer](#install-step-1) |
+| &#10063; | [Step 2: Check cluster health](#install-step-2) |
+| &#10063; | [Step 3: Finalize installation](#install-step-3) |
+
+{: id="install-step-1"}
 ## Step 1. Run the Installer
 2. Copy the downloaded release bundle to `/export/sdb1/TS_TASKS/install`.
 Run `scp <release-number>.tar.gz admin@<hostname>:/export/sdb1/TS_TASKS/install/<file-name>`.
@@ -59,6 +65,7 @@ Run `tscli cluster create <release-number>`.
 
   Log in to any node to check the current cluster status, using the command `tscli cluster status`.
 
+{: id="install-step-2"}
 ## Step 2. Check Cluster Health
 After you install the cluster, check its status using the `tscli cluster status` and `tscli cluster check` commands.
 
@@ -153,6 +160,7 @@ Your output may look something like the above. Ensure that all diagnostics show 
 
 {% include warning.html content="If <code>tscli cluster check</code> returns an error, it may suggest you run <code>tscli storage gc</code> to resolve the issue. If you run <code>tscli storage gc</code>, note that it restarts your cluster." %}
 
+{: id="install-step-3"}
 ## Step 3. Finalize Installation
 
 After the cluster status changes to “Ready,” sign in to the ThoughtSpot application on your browser.<br>

--- a/_appliance/vmware/installing-vmware.md
+++ b/_appliance/vmware/installing-vmware.md
@@ -1,6 +1,6 @@
 ---
 title: [Configure ThoughtSpot nodes in VMware]
-last_updated: 12/12/2019
+last_updated: 3/3/2020
 summary: "Prepare to install your ThoughtSpot cluster by configuring nodes."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
@@ -21,28 +21,11 @@ Ensure the successful creation of the virtual machines (VMs) before you install 
 ## Configure Nodes
 After creating the instance, you must configure the nodes. Follow the steps in this checklist.
 
-<table>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="installing-vmware#node-step-1">Step 1: Log in to your cluster</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="installing-vmware#node-step-2">Step 2: Get a template for network configuration</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="installing-vmware#node-step-3">Step 3: Prepare node configuration</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="installing-vmware#node-step-4">Step 4: Configure the nodes</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="installing-vmware#node-step-5">Step 5: Confirm node configuration</a></td>
-  </tr>
-</table>
+| &#10063; | [Step 1: Log in to your cluster](#node-step-1) |
+| &#10063; | [Step 2: Get a template for network configuration](#node-step-2) |
+| &#10063; | [Step 3: Prepare node configuration](#node-step-3) |
+| &#10063; | [Step 4: Configure the nodes](#node-step-4) |
+| &#10063; | [Step 5: Confirm node configuration](#node-step-5) |
 
 {% include content/install/configure-nodes-steps1through5.md %}
 

--- a/_appliance/vmware/vmware-cluster-install.md
+++ b/_appliance/vmware/vmware-cluster-install.md
@@ -1,6 +1,6 @@
 ---
 title: [Install ThoughtSpot clusters in VMware]
-last_updated: [1/16/2020]
+last_updated: [3/3/2020]
 summary: "Learn how to install ThoughtSpot clusters in VMware."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
@@ -18,20 +18,9 @@ Before you can install your ThoughtSpot clusters in VMware, complete these prere
 ## Install ThoughtSpot Software
 Install the cluster using the ThoughtSpot software release bundle. The estimated installation time is one hour. Follow the steps in this checklist.
 
-<table>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="vmware-cluster-install#cluster-step-1">Step 1: Run the installer</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="vmware-cluster-install#cluster-step-2">Step 2: Check cluster health</a></td>
-  </tr>
-  <tr>
-    <td>&#10063;</td>
-    <td><a href="vmware-cluster-install#cluster-step-3">Step 3: Finalize installation</a></td>
-  </tr>
-</table>
+| &#10063; | [Step 1: Run the installer](#cluster-step-1) |
+| &#10063; | [Step 2: Check cluster health](#cluster-step-2) |
+| &#10063; | [Step 3: Finalize installation](#cluster-step-3) |
 
 Refer to your welcome letter from ThoughtSpot to find the link to download the release bundle. If you do not have a link, open a support ticket at [ThoughtSpot Support](https://support.thoughtspot.com) to request access to the release bundle.
 

--- a/_appliance/vmware/vmware-setup.md
+++ b/_appliance/vmware/vmware-setup.md
@@ -1,7 +1,7 @@
 ---
 title: [Set up ThoughtSpot in VMware]
 summary: Learn how to install a ThoughtSpot cluster in a VMware environment.
-last_updated: 1/10/2020
+last_updated: 3/3/2020
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
@@ -33,7 +33,7 @@ for a sandbox environment but is insufficient for a production environment. You 
 
 2. Create datastores for all solid-state drive (SSD) and hard drive devices.
 
-3. <a href="{{ site.baseurl }}/site-survey.pdf" download>Download</a> and fill out the ThoughtSpot site survey to have a quick reference for any networking information you may need to fill out as you install ThoughtSpot. Ask your network administrator if you need help filling out the site survey.
+3. Download and fill out the ThoughtSpot [site survey]({{ site.baseurl }}/site-survey.pdf){:target="_blank"} to have a quick reference for any networking information you may need to fill out as you install ThoughtSpot. Ask your network administrator if you need help filling out the site survey.
 
 ## Use the OVF to Create a VM
 

--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -1321,6 +1321,9 @@ entries:
 #  - sectiontitle: Dell Installation
 #    output: web,appQs,instDell
 #    sectionitems:
+#    - title: Hardware appliance overview
+#      url: /appliance/hardware/inthebox.html
+#      output: web,appQs,instDell
 #    - title: Deploying on the Dell appliance
 #      url: /appliance/hardware/installing-dell.html
 #      output: web,appQs,instDell
@@ -1374,6 +1377,9 @@ entries:
 #  - sectiontitle: SMC Installation
 #    output: web,appQs,instSMC
 #    sectionitems:
+#    - title: Hardware appliance overview
+#      url: /appliance/hardware/inthebox.html
+#      output: web,appQs,instSMC
 #    - title: Deploying on the SMC appliance
 #      url: /appliance/hardware/installing-the-smc.html
 #      output: web,appQs,instSMC
@@ -1798,6 +1804,9 @@ entries:
     - levelTwoTitle: Deployment reference
       output: web,refGd
       levelTwoItems:
+      - title: Cable reference
+        url: /appliance/hardware/cable-networking.html
+        output: web,appQs,instDell,instSMC
       - title: Network Policies
         url: /appliance/firewall-ports.html
         output: web,refGd

--- a/_includes/content/contact-info.md
+++ b/_includes/content/contact-info.md
@@ -31,6 +31,6 @@ Sunnyvale, CA 94085
 
 | Reason for contacting us | Email |
 | --------------------- | ----- |
-| Sales inquiries | <a href="mailto:sales@thoughtspot.com">sales@thoughtspot.com</a> |
-| Customer support and software update inquiries | <a href="mailto:support@thoughtspot.com">support@thoughtspot.com</a> |
-| Other inquiries | <a href="mailto:hello@thoughtspot.com">hello@thoughtspot.com</a> |
+| Sales inquiries | [sales@thoughtspot.com](mailto:sales@thoughtspot.com) |
+| Customer support and software update inquiries | [support@thoughtspot.com](mailto:support@thoughtspot.com) |
+| Other inquiries | [hello@thoughtspot.com](mailto:hello@thoughtspot.com) |


### PR DESCRIPTION
Per clarifications from Steve Stojanovich, added note about SFP+'s to cable ref and smc and dell prereq pages. Added the cable reference to the sidebar under 'deployment reference.' Finished converting html links to markdown for articles that are going into the deployment pdfs.

Signed-off-by: Teresa Killmond <teresa.killmond@thoughtspot.com>