### PR TITLE
Update GCP disk image information

### DIFF
--- a/_appliance/gcp/launch-an-instance.md
+++ b/_appliance/gcp/launch-an-instance.md
@@ -218,3 +218,4 @@ To install your ThoughtSpot cluster, complete the installation process outlined 
 
 [Connecting to Google Cloud Storage buckets](https://cloud.google.com/compute/docs/disks/gcs-buckets){:target="_blank"}  
 [Loading data from a GCP GCS bucket]({{ site.baseurl }}/admin/loading/use-data-importer.html#loading-data-from-a-gcp-gcs-bucket)
+ 


### PR DESCRIPTION
@mark-plummer 

Please update the screenshot with the right image name (as mentioned in https://thoughtspot.atlassian.net/wiki/spaces/RM/pages/57409971/Location+of+GA+Release+collateral )

Best would be to actually mention the image name from Confluence in plain-text. This way customers/partners can copy-paste the string in their Google account's search box and find an exact match.
We've already done this for AWS AMI (Thank you for that).

Right now customers/partners are being told about an out-of-date image.