### PR TITLE
snapshot/ backup information from saira, per SREs

### DIFF
--- a/_admin/backup-restore/choose-strategy.md
+++ b/_admin/backup-restore/choose-strategy.md
@@ -1,6 +1,6 @@
 ---
 title: [Understand the backup strategies]
-last_updated: 10/14/2019
+last_updated: 3/9/2020
 summary: "Consider the strategies for backing up your ThoughtSpot cluster."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
@@ -8,7 +8,7 @@ permalink: /:collection/:path.html
 {: id="snapshots"}
 ## Snapshots
 
-A snapshot is a point-in-time image of your running cluster. Snapshots are both taken on and restored to a cluster while it is running. Each cluster has a periodic snapshot configuration enabled by default. This configuration instructs the system to periodically take snapshots. Creation of a snapshot takes about 20 seconds. After creation, a snapshot persists on disk in the cluster's HDFS.
+A snapshot is a point-in-time image of your running cluster. Snapshots are both taken on and restored to a cluster while it is running. Each cluster has a periodic snapshot configuration enabled by default. This configuration instructs the system to periodically take snapshots. Creation of a snapshot could take as little as 20 seconds, but depends on the number of objects in your cluster. After creation, a snapshot persists on disk in the cluster's HDFS.
 
 You can also create a snapshot manually. You should create a snapshot before making any changes to the environment, loading a large amount of new data, or changing the structure of a table. A snapshot may only be restored to the same cluster on which it was taken. The cluster software release version must match the snapshot release version.
 
@@ -91,9 +91,10 @@ Depending on your situation and your goals, you can choose to use either a snaps
                     </td>
                     <td>
                         <ul>
-                            <li>Require deleting the existing cluster first.
+                            <li>Requires deleting the existing cluster first.</li>
                             <li>You are responsible for validating your backup configuration as
                                 viable for restoring a cluster.</li>
+                            <li>Backups do not copy over anything that is in the home directories or root partitions of an instance. If you routinely add flat files or scripts directly, make separate copies of these flat files and scripts.</li>
                             <li>Best practice recommends you to maintain multiple backups.</li>
                             <li>Typically, very large in memory size.</li>
                         </ul>
@@ -101,4 +102,4 @@ Depending on your situation and your goals, you can choose to use either a snaps
                 </tr>
             </table>
 
-You should never restore from a snapshot or backup yourself. Contact ThoughtSpot Support for help.
+You should never restore from a snapshot or backup yourself. Contact [ThoughtSpot Support]({{ site.baseurl }}/appliance/contact.html) for help.


### PR DESCRIPTION
Clarified that snapshots can take 20 seconds, but may take longer. Noted that backups do not copy anything in the home directory or root partitions of an instance. Fixed an html issue with the table on /admin/backup-restore/choose-strategy.html, and added a link to TS support.

Signed-off-by: Teresa Killmond <teresa.killmond@thoughtspot.com>