### PR TITLE
6.1: Backup and restore using S3 bucket

### DIFF
--- a/_admin/loading/use-data-importer.md
+++ b/_admin/loading/use-data-importer.md
@@ -77,10 +77,12 @@ You can integrate tsload into your ETL environment for more automated data loads
 
 If you have data in .csv format stored in an AWS bucket, you can load it directly to ThoughtSpot.
 
-### (5.3.1 and later) Assigning S3 read-only role to your EC2 instance
+### Assigning S3 read-only role to your EC2 instance
 If your cluster is running 5.3.1 or later, you can assign an S3 read-only role to your ThoughtSpot EC2 instance(s) so the instance(s) can access the S3 bucket from which you want to load the data. This eliminates the need to enter the AWS S3 credentials when loading your data. For details, see: [Using an IAM Role to Grant Permissions to Applications Running on Amazon EC2 Instances](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html){:target="_blank"} in Amazon's AWS documentation.
 
 {% include note.html content="If you are using S3 for persistent storage, and assigned the *ec2rolewithfulls3access* IAM role to your instance, you do not need to complete this step." %}
+
+If an IAM an role is configured, there is no need to supply the `--s3a_access_key`, `--s3a_secret_key` and `--s3a_region` parameters.
 
 To load data from an AWS S3 bucket, do the following:
 
@@ -89,32 +91,37 @@ To load data from an AWS S3 bucket, do the following:
 2.  Use the following syntax to invoke `tsload`, specifying the appropriate flags and your data source file:
 
     ```
-    $ tsload --source_file "/aws/default/<my_file_in_aws>"
-           --target_database "<my_database_in_ThoughtSpot>" --target_table "<my_table_in_the_database_in_ThoughtSpot>"
-    ```       
+    $ tsload --source_file "/s3a/default/<my_file_in_aws>"
+           --target_database "<my_database_in_ThoughtSpot>" --target_table "<my_table_in_the_database_in_ThoughtSpot>" --s3a_bucket_name <bucket_name>
+    ```   
+    {% include important.html content="--source_file should contain the file path inside the bucket and must be prefixed by “/s3a/default”. For example, to load from a file named “directory/file.csv”, the --source_file should be “/s3a/default/directory/file.csv”." %}
+
+    {% include note.html content="If you do not supply the --s3a_bucket_name, there will be a prompt asking you to enter it." %}
+
     This example imports the CSV file `teams.csv` into the table `teams` in the database `temp`:
 
     ```
     $ tsload --source_file "/aws/default/teams.csv"
            --target_database "temp" --target_table "teams"
-    ```       
+    ```    
+
 3. After running the `tsload` command, you are prompted to enter additional AWS S3 information:
 
-    * AWS S3 bucket name
+    * AWS S3a bucket name
 
-    * AWS S3 region
+    You only need to enter these, if you have no IAM role configured:
 
-    * AWS S3 credentials (accesskey;secret_key)__*__
+    * AWS S3a region
 
-    * AWS S3 root (prefix for S3 object search path)
+    * AWS S3a access key
+
+    * AWS S3a secret key
 
     Optionally, these four pieces of information can be inserted at the beginning of the command (in step 2), using the following flags: <br>
-    * `--aws_s3_bucket_name "<bucket name>"` <br>
-    * `--aws_s3_region "<region name>"` <br>
-    * `--aws_s3_credentials "<credentials>"`__*__ <br>
-    * `--aws_s3_root "<search path>"`
-
-    {% include note.html content="<b>*<b>AWS S3 credentials is not used in the 5.3.1 release, if an S3 read-only role is assigned to your instance." %}
+    * `--s3a_bucket_name "<Name of bucket that contains the source CSV file>"` <br>
+    * `--s3a_region "<Region where the bucket is located>"` <br>
+    * `--s3a_access_key "<AWS S3 access key>"`<br>
+    * `--s3a_secret_key "<AWS S3 secret key>"`<br>
 
 4.  After the processing begins, progress messages appear, and then source and load summary messages after the load is complete.
 

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ locale                   : "en"
 destination              : ./_site
 output                   : web
 # Used to designate the current version. Edit when a new version is released
-current_version          : "6.0"
+current_version          : "6.1"
 # Note that site.baseurl for this site evaluates to:
 # http://docs.thoughtspot.com/<version>/
 # used for conditional content filtering

--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -3,7 +3,7 @@
 entries:
 - title: sidebar
   product: Version
-  version: 6.0 Guides
+  version: 6.1 Guides
   sections:
 # Needed for PDF output only; no titles in this section
   - sectiontitle:

--- a/_release/notes.md
+++ b/_release/notes.md
@@ -6,7 +6,7 @@ sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
 
-ThoughtSpot version 6.1is now available. These release notes include information about new features,
+ThoughtSpot version 6.1 is now available. These release notes include information about new features,
 fixed issues from previous releases, and any known issues.
 
 * [6.1 New Features](#6-new)
@@ -18,14 +18,9 @@ fixed issues from previous releases, and any known issues.
 {: id="6-1-new"}
 ## 6.1 New Features and Functionality
 
-### Backup and Restore from and S3 buckect
+### Backup and Restore from and S3 bucket
 
-This release of ThoughtSpot introduces deployment support for <a href="https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux" target="_blank">RHEL 7.7</a>. This decouples the OS and application files we shipped together in previous releases, and gives you the flexibility to run ThoughtSpot on an RHEL 7.7 image that your organization manages internally.
-ThoughtSpot certifies RHEL 7.7 on the following platforms:
-- ThoughtSpot-configured appliances, both DELL hardware and SMC hardware
-- Cloud deployments: AWS and GCP
-- VMware
-RHEL support is in the Early Access phase. To deploy ThoughtSpot on RHEL, you must have the Ansible tarball; please contact us if you are interested in participating in the <a href="mailto:BetaProgram@thoughtspot.com?subject=RHEL%20Early%20Access%20Program%20Request" target="_blank">RHEL Early Access Program</a>.
+This release of ThoughtSpot introduces . . .
 
 {: id="6-1-fixed"}
 ## 6.1 Fixed Issues
@@ -33,7 +28,6 @@ RHEL support is in the Early Access phase. To deploy ThoughtSpot on RHEL, you mu
 The following issues are fixed in the 6.1 release:
 
 - tbd.
-
 
 {: id="beta-program"}
 ## Beta Programs

--- a/_release/notes.md
+++ b/_release/notes.md
@@ -22,6 +22,10 @@ fixed issues from previous releases, and any known issues.
 
 This release of ThoughtSpot introduces . . .
 
+### Geomap support for Norway and Switzerland
+
+For details, see: [Geo Map reference]({{ site.baseurl }}/reference/geomap-reference.html#)
+
 {: id="6-1-fixed"}
 ## 6.1 Fixed Issues
 


### PR DESCRIPTION
**What's changed:**
- New commands added for backing up to and restoring from an s3 bucket (per Sameer)
- tweaks to 6.1 release notes

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>