### PR TITLE
Provide actual values for performance guidelines

### DIFF
--- a/_admin/architecture/performance.md
+++ b/_admin/architecture/performance.md
@@ -58,4 +58,4 @@ Maximum number of unique RLS rules with search data suggestions should not excee
 
 ## Scheduled Pinboards
 
-For ideal performance of scheduled pinboards, do not exceed 50 scheduled pinboard jobs.
+For ideal performance of scheduled pinboards, do not exceed 50 scheduled pinboard jobs. 


### PR DESCRIPTION
Current text, which is as below, needs to change.

===
Contact ThoughtSpot support for guidance on boundaries for the following:
- Maximum number of rows that can be downloaded
- Size in CSV format
- Total number of rows across all tables
- Many-to-Many (Generic join cardinality)
- Load frequency
===

Instead of sending customer to ThoughtSpot SRE who then has to check with individual engineering L2 teams or with CSAs, shouldn't we provide actual values here for each of the parameters? All of these values are known - but need to come from devs and PM teams.

Can you help @mark-plummer @roza-leyderman-pro ?