### PR TITLE
SCAL-57122

### DIFF
--- a/_appliance/aws/launch-an-instance.md
+++ b/_appliance/aws/launch-an-instance.md
@@ -1,6 +1,6 @@
 ---
 title: [Set up AWS resources for ThoughtSpot]
-last_updated: 3/13/2020
+last_updated: 4/3/2020
 sidebar: mydoc_sidebar
 summary: "After you determine your configuration options, you must set up your virtual machines (VMs) in AWS using a ThoughtSpot Amazon Machine Image (AMI)."
 permalink: /:collection/:path.html
@@ -29,6 +29,8 @@ To make deployment easy, the ThoughtSpot AMI includes a custom ThoughtSpot image
 -   A block device mapping that specifies the volumes to attach to the instance when it launches.
 
 The ThoughtSpot AMI has specific applications on a base image. The AMI includes the EBS volumes necessary to install ThoughtSpot in AWS. When you launch an EC2 instance from this image, it automatically sizes and provisions the EBS volumes. The base AMI includes 200 GB (xvda), 2X400 GB (xvdb), and SSD (gp2). It contains the maximum number of disks to handle a fully loaded VM.
+
+This guide explains how to deploy ThoughtSpot on AWS, using ThoughtSpot's CentOS-based image. Starting with version 6.0.4, you can also deploy ThoughtSpot on AWS using Red Hat Enterprise Linux (RHEL), allowing you to run ThoughtSpot on an RHEL 7.7 image that your organization manages internally. To install ThoughtSpot using RHEL, refer to the [RHEL deployment guide]({{ site.baseurl }}/appliance/rhel/rhel.html).
 
 {: id="prerequisites"}
 ## Prerequisites

--- a/_appliance/azure/launch-an-instance.md
+++ b/_appliance/azure/launch-an-instance.md
@@ -1,6 +1,6 @@
 ---
 title: [Set up ThoughtSpot in Azure]
-last_updated: 3/3/2020
+last_updated: 4/3/2020
 summary: "After you determine your configuration options, you must set up your virtual
 machines using a ThoughtSpot image for Azure."
 sidebar: mydoc_sidebar
@@ -21,6 +21,8 @@ learn about the latest version of the ThoughtSpot Virtual Machine.
 
 Due to security restrictions, the ThoughtSpot Virtual Machine does not have default passwords for the administrator users. When you are ready to obtain the password, contact
 [ThoughtSpot Support]({{ site.baseurl }}/appliance/contact.html).
+
+This guide explains how to deploy ThoughtSpot on Microsoft Azure, using ThoughtSpot's CentOS-based image. Starting with version 6.0.4, you can also deploy ThoughtSpot on Azure using Red Hat Enterprise Linux (RHEL), allowing you to run ThoughtSpot on an RHEL 7.7 image that your organization manages internally. To install ThoughtSpot using RHEL, refer to the [RHEL deployment guide]({{ site.baseurl }}/appliance/rhel/rhel.html).
 
 ## Set up ThoughtSpot in Azure
 

--- a/_appliance/gcp/launch-an-instance.md
+++ b/_appliance/gcp/launch-an-instance.md
@@ -15,6 +15,8 @@ ThoughtSpot uses a custom image to populate VMs in GCP. To find the ThoughtSpot 
 
 Ask your ThoughtSpot contact for access to this image. We need the Google account/email ID of the individual who will be signed into your organization's GCP console. We will share ThoughtSpot's GCP project with them so they can use the contained boot disk image to create ThoughtSpot VMs.
 
+This guide explains how to deploy ThoughtSpot on GCP, using ThoughtSpot's CentOS-based image. Starting with version 6.0.4, you can also deploy ThoughtSpot on GCP using Red Hat Enterprise Linux (RHEL), allowing you to run ThoughtSpot on an RHEL 7.7 image that your organization manages internally. To install ThoughtSpot using RHEL, refer to the [RHEL deployment guide]({{ site.baseurl }}/appliance/rhel/rhel.html).
+
 ## Overview
 
 Before you can create a ThoughtSpot cluster, you must set up your VMs. Use the Google Compute Engine (GCP) platform to create and run VMs.

--- a/_appliance/hardware/installing-dell.md
+++ b/_appliance/hardware/installing-dell.md
@@ -1,7 +1,7 @@
 ---
 title: [Deploying on the Dell appliance]
 summary: "Follow these steps to deploy ThoughtSpot on your Dell appliance."
-last_updated: 3/3/2020
+last_updated: 4/3/2020
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
@@ -13,6 +13,8 @@ Follow the steps in this checklist to deploy ThoughtSpot on your Dell appliance.
 | &#10063; | [Step 4: Configure management settings]({{ site.baseurl }}/appliance/hardware/configure-management-dell.html) |
 | &#10063; | [Step 5: Configure nodes]({{ site.baseurl }}/appliance/hardware/configure-nodes-dell.html) |
 | &#10063; | [Step 6: Install cluster]({{ site.baseurl }}/appliance/hardware/install-cluster-dell.html) |
+
+This guide explains how to deploy ThoughtSpot on a Dell appliance, using ThoughtSpot's CentOS-based image. Starting with version 6.0.4, you can also deploy ThoughtSpot on a Dell appliance using Red Hat Enterprise Linux (RHEL), allowing you to run ThoughtSpot on an RHEL 7.7 image that your organization manages internally. To install ThoughtSpot using RHEL, refer to the [RHEL deployment guide]({{ site.baseurl }}/appliance/rhel/rhel.html).
 
 ## Related information
 Use these references to aid you in successful installation and administration of ThoughtSpot.

--- a/_appliance/hardware/installing-the-smc.md
+++ b/_appliance/hardware/installing-the-smc.md
@@ -1,6 +1,6 @@
 ---
 title: [Deploying on the SMC appliance]
-last_updated: [3/3/2020]
+last_updated: [4/3/2020]
 summary: "Follow these steps to deploy ThoughtSpot on your Super Micro Computer appliance."
 sidebar: mydoc_sidebar
 toc: false
@@ -13,6 +13,8 @@ Follow these steps to deploy ThoughtSpot on your Super Micro Computer (SMC) appl
 | &#10063; | [Step 3: Connect your SMC appliance]({{ site.baseurl }}/appliance/hardware/connect-appliance-smc.html) |
 | &#10063; | [Step 4: Configure nodes]({{ site.baseurl }}/appliance/hardware/configure-nodes-smc.html) |
 | &#10063; | [Step 5: Install cluster]({{ site.baseurl }}/appliance/hardware/smc-cluster-install.html) |
+
+This guide explains how to deploy ThoughtSpot on an SMC appliance, using ThoughtSpot's CentOS-based image. Starting with version 6.0.4, you can also deploy ThoughtSpot on an SMC appliance using Red Hat Enterprise Linux (RHEL), allowing you to run ThoughtSpot on an RHEL 7.7 image that your organization manages internally. To install ThoughtSpot using RHEL, refer to the [RHEL deployment guide]({{ site.baseurl }}/appliance/rhel/rhel.html).
 
 ## Related information
 Use these references to aid you in successful installation and administration of ThoughtSpot.

--- a/_appliance/vmware/vmware-intro.md
+++ b/_appliance/vmware/vmware-intro.md
@@ -17,8 +17,7 @@ the components of a VMware and ThoughtSpot architecture:
 
 ![]({{ site.baseurl }}/images/vmware-components.png)
 
-{% include note.html content="This is a generic representation; Only CentOS-based
-virtual machines are supported with ThoughtSpot." %}
+{% include note.html content="This is a generic representation. ThoughtSpot supports VMware deployment using its CentOS-based image, or on an RHEL 7.7 image that your organization manages internally." %}
 
 Your database capacity will determine the number of ThoughtSpot instances and
 the instance network/storage requirements. In addition, you can scale your

--- a/_appliance/vmware/vmware-setup.md
+++ b/_appliance/vmware/vmware-setup.md
@@ -16,6 +16,9 @@ For each hardware node, you must:
 a virtual machine (VM)
 * Add hard disks to the VM
 
+This guide explains how to deploy ThoughtSpot on VMware, using ThoughtSpot's CentOS-based image. Starting with version 6.0.4, you can also deploy ThoughtSpot on VMware using Red Hat Enterprise Linux (RHEL), allowing you to run ThoughtSpot on an RHEL 7.7 image that your organization manages internally. To install ThoughtSpot using RHEL, refer to the [RHEL deployment guide]({{ site.baseurl }}/appliance/rhel/rhel.html).
+
+
 ## Prerequisites
 
 This installation process assumes you have already acquired your host machines.


### PR DESCRIPTION
Added RHEL link to deployment guides; specified that the TS-managed image is CentOS.

Signed-off-by: Teresa Killmond <teresa.killmond@thoughtspot.com>