### PR TITLE
fixed access include issue

### DIFF
--- a/_complex-search/about-query-on-query.md
+++ b/_complex-search/about-query-on-query.md
@@ -44,7 +44,7 @@ possible. If you want to do this, here are the steps at a high level:
 
 ## Best practices for using views
 
-{% include access.html content="Only users with the [**Can administrator ThoughtSpot** or the **Can manage data** privilege]({{ site.baseurl }}/admin/users-groups/about-users-groups.html) can create views and link them." %}
+{% include access.html content="Only users with the **Can administrator ThoughtSpot** or the **Can manage data** privilege can create views and link them." %}
 
 {% include important.html content="Views do not support row level security (RLS), so all users of a view will be able to see all the data it contains." %}
 


### PR DESCRIPTION
**Note to Roza:** includes of this type cannot have a link inside them. When i tried to rebuild the 6.1 site, it threw an error, and I had to go back and remove the link.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>