### PR TITLE
SCAL-59617, SCAL-52997

### DIFF
--- a/_admin/setup/sync-users-and-groups-from-ldap.md
+++ b/_admin/setup/sync-users-and-groups-from-ldap.md
@@ -2,15 +2,21 @@
 title: [Sync users and groups from LDAP]
 tags: [SAML_LDAP_AD]
 keywords: SAML,security,"active directory",authenticate
-last_updated: tbd
+last_updated: 5/7/2020
 summary: "Use this procedure to synchronize your ThoughtSpot system with an LDAP server."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
 ---
-Before synchronizing users and groups, you will need this information:
+## Prerequisites
 
--   IP address and port of the server where your ThoughtSpot instance is running. This hostport is needed in the following format `http(s)://<host>:<port>` or `http(s)://<domain>`.
+Before synchronizing users and groups, [set up integration with LDAP using Active Directory]({{ site.baseurl }}/admin/setup/LDAP-config-AD.html). Then, collect the following information:
+
+-   IP address and port of the server where your ThoughtSpot instance is running.
+
+    This hostport must be in the following format `http(s)://<host>:<port>` or `http(s)://<domain>`.
+
 -   Administrator login username and password for your ThoughtSpot instance.
+
 -   URL of the LDAP server, or hostport.
 
     For example, `ldap://192.168.2.48:389`
@@ -23,13 +29,22 @@ Before synchronizing users and groups, you will need this information:
 
     For example, `DC=ldap,DC=thoughtspot,DC=com`
 
--   Location of the Python synchronization script, in case you want to modify it or create your own: `/usr/local/scaligent/release/callosum/utilities/ldap_sync_python_api/syncUsersAndGroups.py`
+-   The Python synchronization script, in case you want to modify it or create your own, is here:
+  ```
+  /usr/local/scaligent/release/callosum/utilities/ldap_sync_python_api/syncUsersAndGroups.py
+  ````
+
+## Fetch users and groups from LDAP with Active Directory
 
 There are two ways for you to fetch users and groups from LDAP and populate them
 into your ThoughtSpot system:
 
--   Run the synchronization script in interactive mode, which will walk you through the process (shown here).
--   Create your own Python script by using the ThoughtSpot Python APIs. If you need details on the Python APIs, contact ThoughtSpot Support. If you choose this method, you can run the script periodically using a cron job.
+-   Run the synchronization script in interactive mode, which walks you through the process (shown here).
+-   Create your own Python script by using the ThoughtSpot Python APIs. If you need details on the Python APIs, [contact ThoughtSpot Support]({{ site.baseurl }}/appliance/contact.html). If you choose this method, you can run the script periodically using a cron job.
+
+{% include note.html content="When you run the synchronization script, you perform a one-time sync. You must schedule a recurring sync using a cron job or your own scheduling tool to keep your ThoughtSpot users up to date with your users in LDAP." %}
+
+### Run the sync script
 
 To run the LDAP sync script in interactive mode:
 
@@ -40,7 +55,7 @@ To run the LDAP sync script in interactive mode:
     python syncUsersAndGroups.py interactive
     ```
 
-3. Answer the prompts using the information you collected above. For example:
+3. Answer the prompts using the information you collected above. Specify `2` for the `scope` if you would like to sync all groups, including subgroups. For example:
 
     ```
     Complete URL of TS server in format "http(s)://<host>:<port>": http://10.77.145.24:8088
@@ -73,7 +88,7 @@ To run the LDAP sync script in interactive mode:
 
 4. Alternatively, to input your own shorthand script commands:
 
-    Issue the Python script commands, supplying all of the above information, following this format example:
+    Issue the Python script commands, supplying all this information, following this format example:
 
     ```
     python syncUsersAndGroups.py script \
@@ -91,4 +106,4 @@ To run the LDAP sync script in interactive mode:
     --include_nontree_members
     ```
 
-    The bottom half of the above command example targets sub trees under the DC called TestGroupAlpha and TestGroupBeta, and iterates through them recursively to create/sync users, groups, and their relationships in the ThoughtSpot system. It also deletes any other entities created in the ThoughtSpot system from this LDAP system that are not currently being synced.
+    The bottom half of the preceding command targets sub trees under the DC called TestGroupAlpha and TestGroupBeta, and iterates through them recursively to create/sync users, groups, and their relationships in the ThoughtSpot system. It also deletes any other entities created in the ThoughtSpot system from this LDAP system that are not currently being synced.


### PR DESCRIPTION
Clarified sync with LDAP uses Active Directory. Added a note about needing to schedule periodic syncs, and a note about how to include subgroups when syncing. Split article into sections for better flow

Signed-off-by: Teresa Killmond <teresa.killmond@thoughtspot.com>