### PR TITLE
6.0 smtp

### DIFF
--- a/_admin/setup/set-up-relay-host.md
+++ b/_admin/setup/set-up-relay-host.md
@@ -1,6 +1,6 @@
 ---
 title: [Set the relay host for SMTP (email)]
-last_updated: 3/4/2020
+last_updated: 5/8/2020
 summary: "ThoughtSpot uses emails to send critical notifications to ThoughtSpot Support. A relay host for SMTP traffic routes the alert and notification emails coming from ThoughtSpot through an SMTP email server."
 sidebar: mydoc_sidebar
 permalink: /:collection/:path.html
@@ -14,10 +14,20 @@ Set up SMTP rules to send critical email notifications to ThoughtSpot Support.
 To set up a relay host:
 
 1. Log in to the Linux shell using SSH.
-2. Issue the setup command, providing the IP address of the relay host:
+2. Issue the setup command, providing the IP address of the relay host.
+
+    Starting with ThoughtSpot release 6.0.5, you can specify a custom port to use to connect to the relay host. If you do not specify a port, the system uses the default recommended port, port 25. Use a custom port if port 25 is blocked in your environment. For example, port 25 is blocked in GCP environments.
+
+    To use the default port, run the setup command:
 
     ```
     $ tscli smtp set-relayhost <IP_address>
+    ```
+
+    To use a custom port instead of port 25, run the setup command, specifying the port you want to use:
+
+    ```
+    $ tscli smtp set-relayhost <IP_address>:<custom_port>
     ```
 
 3. Verify your settings:

--- a/_admin/setup/set-up-relay-host.md
+++ b/_admin/setup/set-up-relay-host.md
@@ -16,7 +16,7 @@ To set up a relay host:
 1. Log in to the Linux shell using SSH.
 2. Issue the setup command, providing the IP address of the relay host.
 
-    Starting with ThoughtSpot release 6.0.5, you can specify a custom port to use to connect to the relay host. If you do not specify a port, the system uses the default recommended port, port 25. Use a custom port if port 25 is blocked in your environment. For example, port 25 is blocked in GCP environments.
+    Starting with ThoughtSpot release 6.0.5, you can specify a custom port to connect to the relay host. If you do not specify a port, the system uses the default recommended port, port 25. Use a custom port if port 25 is blocked in your environment. 
 
     To use the default port, run the setup command:
 

--- a/_includes/content/ports-network.md
+++ b/_includes/content/ports-network.md
@@ -107,7 +107,7 @@ ThoughtSpot uses static ports for inbound and outbound access to the cluster.
   |443|TCP|HTTPS|outbound|All nodes|208.83.110.20 |For transferring files to thoughtspot.egnyte.com.|
 |443|TCP|HTTPS|outbound|All nodes|For transferring product usage data to mixpanel cloud.|outbound|
 |443|TCP|HTTPS|outbound|All nodes|je8b47jfif.execute-api.us-east-2.amazonaws.com <br> s3.us-west-1.amazonaws.com <br> s3-us-west-1.amazonaws.com <br> s3.dualstack.us-west-1.amazonaws.com|For transferring monitoring data to InfluxCloud. (Given address will resolve to point to AWS instances).|
-|25 or 587|SMTP|SMTP or Secure SMTP|outbound|All nodes and SMTP relay (provided by customer)|All nodes|Allow outbound access for the IP address of whichever email relay server is in use. This is for sending alerts to ThoughtSpot Support.|
+|25 or 587|SMTP|SMTP or Secure SMTP|outbound|All nodes and SMTP relay (provided by customer)|All nodes|Allow outbound access for the IP address of whichever email relay server is in use. This is for sending alerts to ThoughtSpot Support. <br> Starting with ThoughtSpot release 6.0.5, you can specify a custom port to connect to the relay host, instead of port 25. Refer to <a href="{{ site.baseurl }}/admin/setup/set-up-relay-host.html">Set the relay host for SMTP</a>.|
 |389 or 636|TCP|LDAP or LDAPS|outbound|All nodes and LDAP server (provided by customer)|All nodes|Allow outbound access for the IP address of the LDAP server in use.|
 
 

--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -2087,7 +2087,7 @@ This subcommand has the following options:
 <dlentry>
   <dt><code>tscli smtp set-relayhost [-h] [--force <em>FORCE</em>] <em>relayhost</em></code></dt>
   <dd>
-    <p>Sets the specified <code>relayhost</code> for SMTP (email) sent from the cluster.</p>
+    <p>Sets the specified <code>relayhost</code>, in the form of an IP address, for SMTP (email) sent from the cluster.</p>
     <p>Accepts the following flag:</p>
       <dl>
         <dlentry>
@@ -2095,6 +2095,11 @@ This subcommand has the following options:
           <dd><p>Set even if relay host is not accessible.</p>
             <p>The default setting is <code>False</code>.</p></dd></dlentry>
     </dl>
+    <p>Starting with ThoughtSpot release 6.0.5, you can specify a custom port to use to connect to the relay host. If you do not specify a port, the system uses the default recommended port, port 25. Use a custom port if port 25 is blocked in your environment. For example, port 25 is blocked in GCP environments.</p>
+    <p>To use the default port, run the setup command normally:</p>
+    <p><code>$ tscli smtp set-relayhost <em>IP_address</em></code></p>
+    <p>To use a custom port instead of port 25, run the setup command, specifying the port you want to use:</p>
+    <p><code>$ tscli smtp set-relayhost <em>IP_address</em>:<em>custom_port</em></code></p>
   </dd></dlentry>
 <dlentry>
     <dt><code>tscli smtp set-saslcredentials</code></dt>

--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -1,6 +1,6 @@
 ---
 title: [tscli command reference]
-last_updated: 11/13/2019
+last_updated: 5/8/2020
 summary: "The ThoughtSpot command line interface, or tscli, is an administration interface for the cluster. Use tscli to take snapshots (backups) of data, apply
 updates, stop and start the services, and view information about the system.
 This reference defines each subcommand."
@@ -2095,7 +2095,7 @@ This subcommand has the following options:
           <dd><p>Set even if relay host is not accessible.</p>
             <p>The default setting is <code>False</code>.</p></dd></dlentry>
     </dl>
-    <p>Starting with ThoughtSpot release 6.0.5, you can specify a custom port to use to connect to the relay host. If you do not specify a port, the system uses the default recommended port, port 25. Use a custom port if port 25 is blocked in your environment. For example, port 25 is blocked in GCP environments.</p>
+    <p>Starting with ThoughtSpot release 6.0.5, you can specify a custom port to connect to the relay host. If you do not specify a port, the system uses the default recommended port, port 25. Use a custom port if port 25 is blocked in your environment.</p>
     <p>To use the default port, run the setup command normally:</p>
     <p><code>$ tscli smtp set-relayhost <em>IP_address</em></code></p>
     <p>To use a custom port instead of port 25, run the setup command, specifying the port you want to use:</p>


### PR DESCRIPTION
Added the custom ports option to the set up relayhost article, tscli command ref, and network ports reference for 6.0.5.