### PR TITLE
VMware data disk usage - modification suggested

### DIFF
--- a/_appliance/vmware/vmware-intro.md
+++ b/_appliance/vmware/vmware-intro.md
@@ -47,13 +47,13 @@ _minimum specifications_ for an individual VMware ESXi host machine:
 	    <tr>
 	      <td>100 GB</td>
 	      <td>32/256 GB</td>
-	      <td>800 GB</td>
+	      <td>2x 400 GB</td>
 				<td>200 GB for each node</td>
         </tr>
 	    <tr>
 	      <td>256 GB</td>
 	      <td>72/512 GB</td>
-	      <td>6 TB</td>
+	      <td>2x 2 TB</td>
 				<td>200 GB for each node</td>
         </tr>
 		<tr>


### PR DESCRIPTION
@mark-plummer @roza-leyderman-pro 

Instead of 800GB data disk for 100GB memory capacity/node, we should state 2x 400GB
Instead of 6TB data disk for 256GB memory/capacity/node, we should state 2x 1TB

Please run this by Sameer Satyam + Simon + Rajesh Kumar before amending.