### PR TITLE
Corrected the names of "Instance type" in 3 places

### DIFF
--- a/_appliance/azure/configuration-options.md
+++ b/_appliance/azure/configuration-options.md
@@ -15,7 +15,7 @@ All Azure VMs (nodes) in a ThoughtSpot cluster must be in the same availability 
 
 | Per VM user data capacity | Instance type | CPU/RAM | Recommended per-VM <br>Premium SSD Managed Disk volume | Required root volume capacity |
 | --- | --- | --- |--- | --- |
-| 200 GB | E64sv3 | 64/432 | 2x1 TB | 200 GB for each node |
-| 100 GB | E32sv3 | 32/256 | 2X 400 GB | 200 GB for each node |
-| 20 GB | E16sv3 | 16/128 | 2X 400 GB | 200 GB for each node |
-| 120 GB | D64v3 | 64/256 | 2X 1 TB | 200 GB for each node |
+| 200 GB | E64s_v3 | 64/432 | 2x1 TB | 200 GB for each node |
+| 100 GB | E32s_v3 | 32/256 | 2X 400 GB | 200 GB for each node |
+| 20 GB | E16s_v3 | 16/128 | 2X 400 GB | 200 GB for each node |
+| 120 GB | D64_v3 | 64/256 | 2X 1 TB | 200 GB for each node |


### PR DESCRIPTION
Corrected the names of "Instance type" in 3 places.

This needs to be committed from https://docs.thoughtspot.com/5.2/appliance/azure/configuration-options.html onwards for every release. Basically our instance type names are missing an underscore before v2/v3 naming.