### PR TITLE
SCAL-63826 removal of whitelist 6.1

### DIFF
--- a/_admin/manage-jobs/schedule-a-pinboard-job.md
+++ b/_admin/manage-jobs/schedule-a-pinboard-job.md
@@ -61,7 +61,7 @@ To schedule a pinboard:
      </tr>
      <tr>
        <th>Recipients</th>
-       <td><p>You are limited to 1000 recipients per job. You can add <b>Users or groups</b> to enter ThoughtSpot users or groups. Use <b>Emails</b> to add recipients that are not ThoughtSpot users. Any users your ThoughtSpot admin must have set your whitelist domains. Contact ThoughtSpot Support to set your whitelist domains.</p>
+       <td><p>You are limited to 1000 recipients per job. You can add <b>Users or groups</b> to enter ThoughtSpot users or groups. Use <b>Emails</b> to add recipients that are not ThoughtSpot users. Your ThoughtSpot admin must set these email domains as allowed domains. Contact ThoughtSpot Support to add allowed domains.</p>
        <p>If you experience problems with sending email, your cluster may not have SMTP enabled. Contact your system administrator to resolve this issue.</p>
        </td>
      </tr>

--- a/_admin/setup/work-with-ts-support.md
+++ b/_admin/setup/work-with-ts-support.md
@@ -22,8 +22,8 @@ This access can be granted and revoked easily, so you can enable it for a troubl
 session, and then disable it again. Before doing this procedure, make sure your
 company's security policies allow reverse tunneling.
 
-{% include note.html content="Before you set up a reverse tunnel, open port `22`
-in your firewall outgoing rules to whitelist `tunnelrelay.thoughtspot.com`." %}
+{% include note.html content="Before you set up a reverse tunnel, open port <code>22</code>
+in your firewall outgoing rules to add <code>tunnelrelay.thoughtspot.com</code> to your list of allowed domains." %}
 
 {: id="remote-support-tscli"}
 ## Using remote support with tscli

--- a/_admin/users-groups/add-user.md
+++ b/_admin/users-groups/add-user.md
@@ -81,7 +81,7 @@ To create a new user and assign that user to groups, follow these steps:
         <th>Email</th>
         <td>Yes</td>
         <td>The user's email address. ThoughtSpot uses this for  notification when another user shares something with them, for onboarding, for the <strong>Ask an Expert</strong> feature, and others.
-        <p>Note that during cluster configuration, the domain is specified. ThoughtSpot does not accept emails outside this domain. <a href="{{ site.baseurl }}/appliance/contact.html">Contact ThoughtSpot Support</a> to whitelist domains. </p></td>
+        <p>Note that during cluster configuration, the domain is specified. ThoughtSpot does not accept emails outside this domain. <a href="{{ site.baseurl }}/appliance/contact.html">Contact ThoughtSpot Support</a> to add new domains to your list of allowed domains. </p></td>
       </tr>    
       <tr id="welcome-email">     
         <th>Send a welcome email</th>

--- a/_data-connect/setup/before-using-data-connect.md
+++ b/_data-connect/setup/before-using-data-connect.md
@@ -16,7 +16,7 @@ The following prerequisites and considerations apply to the data connect feature
 - If you want to use HTTPS with your URL, you must provide a signed certificate when enabling ThoughtSpot Data Connect.
 - You need outbound HTTPS (port 443 for infaagent) internet access to [https://app.informaticaondemand.com](https://app.informaticaondemand.com/) and [https://app2.informaticacloud.com/](https://app2.informaticacloud.com/).
 
-    If outbound HTTPS internet access to [https://app.informaticaondemand.com](https://app.informaticaondemand.com/) and [https://app2.informaticacloud.com/](https://app2.informaticacloud.com/) is not possible, you can instead whitelist the Informatica Cloud IP address ranges `206.80.52.0/24`, `206.80.61.0/24`, `209.34.91.0/24`, and `209.34.80.0/24`.
+    If outbound HTTPS internet access to [https://app.informaticaondemand.com](https://app.informaticaondemand.com/) and [https://app2.informaticacloud.com/](https://app2.informaticacloud.com/) is not possible, you can instead add the Informatica Cloud IP address ranges `206.80.52.0/24`, `206.80.61.0/24`, `209.34.91.0/24`, and `209.34.80.0/24` to your list of allowed domains.
 
 - You will also need any other internet connectivity and credentials required to access any cloud data sources you want to connect to, such as Salesforce. No inbound access is required.
 - After ThoughtSpot Data Connect is enabled, any user who belongs to a group with **Has administration privileges** or who **Can Manage Data** can use the feature. Before enabling the feature, in sure that these privileges are configured properly.

--- a/_data-integrate/embrace/embrace-snowflake-partner.md
+++ b/_data-integrate/embrace/embrace-snowflake-partner.md
@@ -21,7 +21,7 @@ ThoughtSpot in Snowflake Partner Connect benefits:
 - A Snowflake account
 
   If you don't have an account, you can sign up for a [free trial](https://trial.snowflake.com/){:target="_blank"}.
-- Whitelist the **try.thoughtspot.com** IP address in your Snowflake account: `35.164.213.211`   
+- Add the **try.thoughtspot.com** IP address to your list of allowed domains in your Snowflake account: `35.164.213.211`   
 - Read the [best practices for Embrace with Snowflake]({{ site.baseurl }}/data-integrate/embrace/embrace-snowflake-best.html).  
 
 ## Sign up for the ThoughtSpot free trial in Snowflake Partner Connect

--- a/_end-user/onboarding/intro-onboarding.md
+++ b/_end-user/onboarding/intro-onboarding.md
@@ -17,7 +17,7 @@ When you create a new user, we recommend that you add them to a user group immed
 {: id="onboarding-valid-email"}
 - **Valid emails**  All users must have valid emails.
 
-  To include users in the onboarding process, each user profile must include a valid email address; see [Create a user]({{ site.baseurl }}/admin/users-groups/add-user.html#add-user). [Contact ThoughtSpot Support]({{ site.baseurl }}/appliance/contact.html) to whitelist email domains.  
+  To include users in the onboarding process, each user profile must include a valid email address; see [Create a user]({{ site.baseurl }}/admin/users-groups/add-user.html#add-user). [Contact ThoughtSpot Support]({{ site.baseurl }}/appliance/contact.html) to add new email domains to your list of allowed domains.  
 
   To load and validate user information (including email addresses) in bulk, we recommend using Active Directory configuration and sync. See [Configure LDAP for Active Directory]({{ site.baseurl }}/admin/setup/LDAP-config-AD.html).
 

--- a/_includes/content/share-answersandpinboards-specify-permissions.md
+++ b/_includes/content/share-answersandpinboards-specify-permissions.md
@@ -8,9 +8,9 @@
 
     ![Enter users or groups]({{ site.baseurl }}/images/sharing-textbox.png "Enter users or groups")
 
-    Note that you can only enter whitelisted email addresses. Whitelisted email domains appear when you click on the info button ![]({{ site.baseurl }}/images/icon-info.png){: .inline}.
+    Note that you can only enter email addresses whose domains are in your list of allowed domains. These email domains appear when you click on the info button ![]({{ site.baseurl }}/images/icon-info.png){: .inline}.
 
-    {% include tip.html content="If you want to hide the whitelisted email domains for your company, or otherwise customize them, contact ThoughtSpot support." %}
+    {% include tip.html content="If you want to hide the allowed email domains for your company, or otherwise customize them, contact ThoughtSpot support." %}
 
 5. Configure the level of access by selecting from the drop-down list. You can select:
     -   **Can View** to provide read-only access. If the user doesn't have access to the underlying worksheet, they can only view the shared object.

--- a/_reference/tscli-command-ref.md
+++ b/_reference/tscli-command-ref.md
@@ -2009,8 +2009,8 @@ This subcommand has the following options:
   </dl>
 
 {% include note.html content="When you enable scheduled pinboards, you should
-also configure a whitelist of intended email domains. Contact ThoughtSpot
-Support for help on how to configure a whitelist." %}
+also configure a list of intended email domains. Contact ThoughtSpot
+Support for help on how to configure this list." %}
 
 {: id="tscli-set"}
 ### set


### PR DESCRIPTION
We are waiting for a new industry standard to appear (blocklist and allowlist seem likely, but are not currently as easily understand as whitelisting is now). In the meantime, removed the words 'whitelist' and 'blacklist' from the docs, replacing with 'list of allowed domains'

Signed-off-by: Teresa Killmond <teresa.killmond@thoughtspot.com>