### PR TITLE
smtp changes

### DIFF
--- a/_admin/admin-portal/smtp-configure.md
+++ b/_admin/admin-portal/smtp-configure.md
@@ -1,6 +1,6 @@
 ---
 title: [Set the relay host for SMTP (email)]
-last_updated: 7/27/2020
+last_updated: 8/13/2020
 summary: ThoughtSpot uses emails to send critical notifications to ThoughtSpot Support. A relay host for SMTP traffic routes the alert and notification emails coming from ThoughtSpot through an SMTP email server.
 toc: true
 sidebar: mydoc_sidebar
@@ -8,3 +8,28 @@ permalink: /:collection/:path.html
 ---
 
 {% include content/admin-portal/smtp-configure.md %}
+
+### Configure an email to receive alerts
+
+ThoughtSpot sends alerts to the email address specified during installation. If you do not specify an email address, you do not receive any alerts. To add an email to receive alerts, `ssh` into your cluster from the command line and issue the following command.
+
+{% include note.html content="Add the ThoughtSpot Support alert email, <code>prod-alerts@thoughtspot.com</code>, to allow ThoughtSpot Support to receive alerts. ThoughtSpot Support monitors these alerts to ensure your cluster's health. Do not add this email to POC or demo environments." %} 
+
+```
+$ tscli monitoring set-config --email <prod-alerts@thoughtspot.com>,<your_email>
+```
+
+To send to multiple emails, provide a comma-separated list with no spaces.
+
+### Verify the relay with an email
+
+Check if the email settings are working properly by using this procedure.
+
+ 1. Log in to the Linux shell using SSH.
+ 2. Try sending an email to yourself by issuing:
+
+    ```
+    $ echo | mail -s Hello <your_email>
+    ```
+
+ 3. If you receive the email at the address(es) you supplied, email is working correctly.

--- a/_admin/setup/set-up-relay-host.md
+++ b/_admin/setup/set-up-relay-host.md
@@ -43,16 +43,20 @@ To set up a relay host:
 
 4. Verify that email is working.
 
+{: id="configure-email"}
 ### Configure an email to receive alerts
 
-ThoughtSpot sends alerts to the email address specified during installation. If no email address was entered, no alerts are sent. You should add an email to receive alerts by issuing:
+ThoughtSpot sends alerts to the email address specified during installation. If you do not specify an email address, you do not receive any alerts. To add an email to receive alerts, issue the following command.
+
+{% include note.html content="Add the ThoughtSpot Support alert email, <code>prod-alerts@thoughtspot.com</code>, to allow ThoughtSpot Support to receive alerts. ThoughtSpot Support monitors these alerts to ensure your cluster's health. Do not add this email to POC or demo environments." %}
 
 ```
-$ tscli monitoring set-config --email <your_email>
+$ tscli monitoring set-config --email <prod-alerts@thoughtspot.com>,<your_email>
 ```
 
 To send to multiple emails, provide a comma-separated list with no spaces.
 
+{: id="verify-email"}
 ### Verify the relay with an email
 
 Check if the email settings are working properly by using this procedure.
@@ -68,3 +72,5 @@ Check if the email settings are working properly by using this procedure.
 
 {: id="admin-portal"}
 {% include content/admin-portal/smtp-configure.md %}
+
+After you configure SMTP through the Administration Portal, use `tscli` to [configure an email to receive monitoring alerts](#configure-email) and [verify the relay with an email](#verify-email).

--- a/_includes/content/admin-portal/smtp-configure.md
+++ b/_includes/content/admin-portal/smtp-configure.md
@@ -1,6 +1,11 @@
 ## Configure SMTP through the Administration Portal
 
-To configure SMTP, navigate to the Administration Portal by clicking on the **Admin** tab from the top navigation bar. Select **SMTP** from the side navigation bar that appears.
+You can set up the relay host for SMTP from the Administration Portal.
+
+{% include note.html content="If you would like to use a custom port, rather than the default, port 25, you must configure SMTP using <code>tscli</code>." %}
+
+### Set up relay host
+Navigate to the Administration Portal by clicking on the **Admin** tab from the top navigation bar. Select **SMTP** from the side navigation bar that appears.
 
 ![Admin Portal - SMTP]({{ site.baseurl }}/images/admin-portal-smtp.png "Admin Portal - SMTP")
 


### PR DESCRIPTION
Added information on configuring monitoring after setting up SMTP -- recommended that users add prod-alerts@thoughtspot.com to their monitoring, so SREs get alerts. 

Signed-off-by: Teresa Killmond <teresa.killmond@thoughtspot.com>