### PR TITLE
Cloud docs: Updated netlify.toml to add tscloud6 redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 ## This redirects to other doc branches
 
 [[redirects]]
-  from = "/tscloud5/*"
+  from = "/tscloud6/*"
   to = "https://cloud-docs.thoughtspot.com/:splat"
   status = 200
   force = true # COMMENT: ensure that we always redirect


### PR DESCRIPTION
 for Cloud in-product links to documentation