### PR TITLE
updated redirects from tscloud6 to ts6.oct.cl

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,8 @@
   to = "https://cloud-docs.thoughtspot.com/:splat"
   status = 200
   force = true # COMMENT: ensure that we always redirect
+
+  from = "/ts6.oct.cl/*"
+  to = "https://cloud-docs.thoughtspot.com/:splat"
+  status = 200
+  force = true # COMMENT: ensure that we always redirect


### PR DESCRIPTION
doc links were not working because engineering implemented `ts6.oct.cl` instead of `tscloud6` (which was the original agreement).

Changed redirect to use `ts6.oct.cl`

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>