### PR TITLE
6.2: SCAL-71981 - Embrace does not support joins across connections

### DIFF
--- a/_data-integrate/embrace/embrace-intro.md
+++ b/_data-integrate/embrace/embrace-intro.md
@@ -30,6 +30,8 @@ You create a connection to the external database, choosing the columns from each
 
 ## Limitations
 
+{% include important.html content="Embrace does not support joins across connections." %}
+
 ### Feature availability in Embrace
 
 The following matrix compares the features that are available in our internal high-performance database, Falcon, and the ones available in Embrace:


### PR DESCRIPTION
Added note to Embrace overview page to indicate it does not support joins across connections.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>