### PR TITLE
fixed privileges page to mention can schedule pinboards is behind a flag

### DIFF
--- a/_admin/users-groups/about-users-groups.md
+++ b/_admin/users-groups/about-users-groups.md
@@ -1,6 +1,5 @@
 ---
 title: ["Understand groups and privileges"]
-
 last_updated: 6/1/2020
 summary: "Creating groups and assigning users to them makes privilege management easier."
 sidebar: mydoc_sidebar

--- a/_includes/content/privileges.md
+++ b/_includes/content/privileges.md
@@ -30,7 +30,7 @@
     </dlentry>
     <dlentry id="schedule-pinboards">
       <dt>Can schedule pinboards</dt>
-      <dd>Can create and edit Pinboard schedules for other users and groups. Without this privilege, users can only create Pinboard schedules for themselves.</dd>
+      <dd>Can create and edit Pinboard schedules for other users and groups. Without this privilege, users can only create Pinboard schedules for themselves. This feature is not available by default. Contact ThoughtSpot support to enable it.</dd>
     </dlentry>
     <dlentry id="spotiq">
       <dt>Has SpotIQ privilege</dt>
@@ -46,9 +46,9 @@
       <p>Your installation configuration may enable or disable the availability of this privilege. By default, it is enabled. Administrators or groups with the privilege <strong>Can administer ThoughtSpot</strong> can grant this privilege.</p></dd>
     </dlentry>
     <dlentry id="read-only">
-      <dt>Cannot create or update Pinboads</dt>
+      <dt>Cannot create or update Pinboards</dt>
       <dd><p>Users are limited to viewing and exploring curated Pinboards (and Answers). They cannot copy, edit, download, or share them.</p>
-      <p>This privilege is designed to support embedded implementations, and it is behind a flag.</p>
+      <p>This privilege is designed to support embedded implementations, and is not available by default. Contact ThoughtSpot support to enable it.</p>
       <p>See <a href="{{ site.baseurl }}/end-user/introduction/pinboard-granular-permission.html">Granular access to Pinboards</a> for a deeper discussion of this privilege, and an implementation example.</p></dd>
     </dlentry>
   </dl>


### PR DESCRIPTION
per guidance from grant robson and bill back.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>