### PR TITLE
6.3: fix for broken dataflow jdbc navigation

### DIFF
--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -2000,13 +2000,13 @@ entries:
         output: web,dataflowGD
         levelThreeItems:
         - title: Overview
-          url: /data-integrate/dataflow/dataflow-jdbc-db2.html
+          url: /data-integrate/dataflow/dataflow-jdbc.html
           output: web,dataflowGd
         - title: Connect
-          url: /data-integrate/dataflow/dataflow-jdbc-db2-add.html
+          url: /data-integrate/dataflow/dataflow-jdbc-add.html
           output: web,dataflowGd
         - title: Sync
-          url: /data-integrate/dataflow/dataflow-jdbc-db2-sync.html
+          url: /data-integrate/dataflow/dataflow-jdbc-sync.html
           output: web,dataflowGd
         - title: Reference
           url: /data-integrate/dataflow/dataflow-jdbc-reference.html


### PR DESCRIPTION
**Fixed the following broken links from the Dataflow > Database connections section:**
- Overview
- Connect
- Sync

Pointed out by Dan Howell

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>