### PR TITLE
April Cloud: revised redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,11 @@
 ## This redirects to other doc branches
 
 [[redirects]]
+  from = "/ts7.apr.cl/*"
+  to = "https://cloud-docs.thoughtspot.com/:splat"
+  status = 200
+  force = true # COMMENT: ensure that we always redirect
+[[redirects]]
   from = "/ts7.april.cl/*"
   to = "https://cloud-docs.thoughtspot.com/:splat"
   status = 200


### PR DESCRIPTION
Revised per finding use of /ts7.apr.cl/ on champagne.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>