### PR TITLE
April Cloud: removed dead link to Oracle adw on embrace overview page

### DIFF
--- a/_admin/ts-cloud/embrace.md
+++ b/_admin/ts-cloud/embrace.md
@@ -13,7 +13,8 @@ On ThoughtSpot Cloud, Embrace supports the following external databases:
 - [Amazon Redshift]({{ site.baseurl }}/admin/ts-cloud/ts-cloud-embrace-redshift.html)
 - [Google BigQuery]({{ site.baseurl }}/admin/ts-cloud/ts-cloud-embrace-gbq.html)
 - [Azure Synapse]({{ site.baseurl }}/admin/ts-cloud/ts-cloud-embrace-synapse.html)
-- [Oracle Autonomous Data Warehouse]({{ site.baseurl }}/admin/ts-cloud/ts-cloud-embrace-adw.html)
+
+{% include note.html content="Oracle Autonomous Data Warehouse is in beta and disabled by default. To enable this feature, contact ThoughtSpot Support." %}
 
 ## How it works
 


### PR DESCRIPTION
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>